### PR TITLE
docs: reconcile convex-component plan with implementation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,13 @@
 # System Architecture Guide
 
+> **Note (2026-08):** The repo is now a bun workspace. The application
+> described below lives in the `app/` workspace (paths like `convex/…` and
+> `src/…` are under `app/`), and its data is stored in the `@caden/json-cms`
+> Convex component (`packages/json-cms/`) rather than app-owned tables — the
+> app re-exports the component's API via `exposeApi` under the same function
+> names used here. This document still describes the app's behavior
+> accurately; a full rewrite for the new layout is a follow-up.
+
 ## Overview
 
 A JSON data management application built with React, Convex (backend/database), and TanStack Router. The system enables users to define JSON schemas and create/manage data entries that conform to those schemas.

--- a/docs/spec/001-convex-component/02-plan.md
+++ b/docs/spec/001-convex-component/02-plan.md
@@ -1,5 +1,35 @@
 # Convex Component Plan: JSON Data Manager
 
+> ## Reconciliation (status vs. plan) — 2026-08
+>
+> This document is the **original** planning artifact. Several details below
+> did not survive contact with the implementation. What actually shipped:
+>
+> - **Table prefixes (`jdm_`) — rejected.** Convex components are
+>   table-namespace isolated, so the component's tables are plain `schemas`
+>   and `entries` (see `packages/json-cms/src/component/schema.ts`). No
+>   prefixing is needed to avoid host-app collisions.
+> - **Package name / path.** The component is published as `@caden/json-cms`
+>   and lives at `packages/json-cms/` (not `packages/json-data-manager/`).
+> - **Not implemented (deferred / out of scope).** `slug` + `by_slug` /
+>   `by_title` indexes, cursor pagination on `listSchemas`, and `metadata`
+>   fields are not built. The current API is straightforward CRUD
+>   (`listSchemas`, `getSchema`, `createSchema`, `updateSchema`,
+>   `deleteSchema`, `listEntries`, `getEntry`, `createEntry`,
+>   `createEntriesBulk`, `updateEntry`, `deleteEntry`,
+>   `deleteEntriesBySchema`), plus `uiSchema` support on schemas.
+> - **Current repo shape.** The root is now a pure bun workspace. The full
+>   reference app lives in its own `app/` workspace and consumes
+>   `@caden/json-cms` through authenticated `exposeApi` re-exports; the
+>   component keeps a minimal internal `example/` as its dev/codegen host.
+> - **Still pending.** The component's React layer
+>   (`packages/json-cms/src/react/` hooks + a `react/ui` component layer) is
+>   not built yet — the app still uses its own local UI. Real auth (the app
+>   currently allows anonymous access) is also a follow-up.
+>
+> The sections below are preserved as originally written for historical
+> context.
+
 ## Overview
 
 Convert the JSON Data Manager into a reusable, publishable Convex component. This involves restructuring the existing repository into a **monorepo** with the component as a package under `packages/json-data-manager/`. The component will provide:


### PR DESCRIPTION
## Summary

Final PR (4 of 4) in the stack. Reconciles the stale planning docs with what actually shipped — no code changes.

- **`docs/spec/001-convex-component/02-plan.md`** — prepends a "Reconciliation (status vs. plan)" note. The original plan is preserved below it for history. Records:
  - `jdm_` table prefixes **rejected** (Convex components are table-namespace isolated).
  - Real package name/path: `@caden/json-cms` at `packages/json-cms/`.
  - Deferred/unbuilt: `slug` + indexes, cursor pagination, `metadata`.
  - Current shape: pure workspace root, app in `app/` consuming the component, `uiSchema` support.
  - Still pending: the React layer and real auth.
- **`docs/architecture.md`** — adds a top note that the app now lives under `app/` and stores data in the component; a full rewrite is deferred.

## Stack

1. `feat/json-cms-uischema` — component `uiSchema` + exported ID types (PR #2)
2. `feat/app-workspace` — move root app into `app/` workspace (PR #3)
3. `feat/app-consume-component` — wire `app/convex` to the component + frontend (PR #4)
4. **→ this PR** — reconcile the plan docs

## Verification

Docs-only; no build/test impact. Prose reviewed for accuracy against the shipped code in the stack.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHpgFbYdFnDGNdUqvig14P)_