### PR TITLE
feat(json-cms): add react hooks + utilities layer

### DIFF
--- a/packages/json-cms/src/react/hooks.ts
+++ b/packages/json-cms/src/react/hooks.ts
@@ -1,0 +1,125 @@
+"use client";
+
+import { useCallback } from "react";
+import { useMutation, useQuery } from "convex/react";
+import type { SchemaId, EntryId } from "../client/index.js";
+import type { SchemaDoc, EntryDoc } from "./types.js";
+import { useJsonCmsApi } from "./provider.js";
+
+// --- Schema queries ---
+
+/** List all schemas, newest first. `undefined` while loading. */
+export function useSchemas(): SchemaDoc[] | undefined {
+  const api = useJsonCmsApi();
+  return useQuery(api.listSchemas, {}) as SchemaDoc[] | undefined;
+}
+
+/**
+ * Get a single schema by id. Pass `undefined` to skip the query.
+ * Returns `null` if the schema does not exist, `undefined` while loading.
+ */
+export function useSchema(schemaId: SchemaId | undefined): SchemaDoc | null | undefined {
+  const api = useJsonCmsApi();
+  return useQuery(api.getSchema, schemaId ? { schemaId } : "skip") as
+    | SchemaDoc
+    | null
+    | undefined;
+}
+
+// --- Entry queries ---
+
+/** List entries for a schema, newest first. Pass `undefined` to skip. */
+export function useEntries(schemaId: SchemaId | undefined): EntryDoc[] | undefined {
+  const api = useJsonCmsApi();
+  return useQuery(api.listEntries, schemaId ? { schemaId } : "skip") as EntryDoc[] | undefined;
+}
+
+/** Get a single entry by id. Pass `undefined` to skip. */
+export function useEntry(entryId: EntryId | undefined): EntryDoc | null | undefined {
+  const api = useJsonCmsApi();
+  return useQuery(api.getEntry, entryId ? { entryId } : "skip") as EntryDoc | null | undefined;
+}
+
+// --- Schema mutations ---
+
+export function useCreateSchema() {
+  const api = useJsonCmsApi();
+  const fn = useMutation(api.createSchema);
+  return useCallback(
+    (args: { schema: unknown; uiSchema?: unknown }): Promise<SchemaId> =>
+      fn(args) as Promise<SchemaId>,
+    [fn],
+  );
+}
+
+export function useUpdateSchema() {
+  const api = useJsonCmsApi();
+  const fn = useMutation(api.updateSchema);
+  return useCallback(
+    (args: {
+      schemaId: SchemaId;
+      title?: string;
+      description?: string;
+      schema?: unknown;
+      uiSchema?: unknown;
+    }): Promise<null> => fn(args) as Promise<null>,
+    [fn],
+  );
+}
+
+export function useDeleteSchema() {
+  const api = useJsonCmsApi();
+  const fn = useMutation(api.deleteSchema);
+  return useCallback(
+    (args: { schemaId: SchemaId }): Promise<null> => fn(args) as Promise<null>,
+    [fn],
+  );
+}
+
+// --- Entry mutations ---
+
+export function useCreateEntry() {
+  const api = useJsonCmsApi();
+  const fn = useMutation(api.createEntry);
+  return useCallback(
+    (args: { schemaId: SchemaId; data: unknown }): Promise<EntryId> => fn(args) as Promise<EntryId>,
+    [fn],
+  );
+}
+
+export function useCreateEntriesBulk() {
+  const api = useJsonCmsApi();
+  const fn = useMutation(api.createEntriesBulk);
+  return useCallback(
+    (args: { schemaId: SchemaId; dataArray: unknown[] }): Promise<EntryId[]> =>
+      fn(args) as Promise<EntryId[]>,
+    [fn],
+  );
+}
+
+export function useUpdateEntry() {
+  const api = useJsonCmsApi();
+  const fn = useMutation(api.updateEntry);
+  return useCallback(
+    (args: { entryId: EntryId; data: unknown }): Promise<null> => fn(args) as Promise<null>,
+    [fn],
+  );
+}
+
+export function useDeleteEntry() {
+  const api = useJsonCmsApi();
+  const fn = useMutation(api.deleteEntry);
+  return useCallback(
+    (args: { entryId: EntryId }): Promise<null> => fn(args) as Promise<null>,
+    [fn],
+  );
+}
+
+export function useDeleteEntriesBySchema() {
+  const api = useJsonCmsApi();
+  const fn = useMutation(api.deleteEntriesBySchema);
+  return useCallback(
+    (args: { schemaId: SchemaId }): Promise<number> => fn(args) as Promise<number>,
+    [fn],
+  );
+}

--- a/packages/json-cms/src/react/index.ts
+++ b/packages/json-cms/src/react/index.ts
@@ -1,7 +1,37 @@
 "use client";
 
-// This is where React components / hooks go.
+// Provider + context
+export { JsonCmsProvider, useJsonCmsApi } from "./provider.js";
 
-export const useMyComponent = () => {
-  return {};
-};
+// Hooks
+export {
+  useSchemas,
+  useSchema,
+  useEntries,
+  useEntry,
+  useCreateSchema,
+  useUpdateSchema,
+  useDeleteSchema,
+  useCreateEntry,
+  useCreateEntriesBulk,
+  useUpdateEntry,
+  useDeleteEntry,
+  useDeleteEntriesBySchema,
+} from "./hooks.js";
+
+// Types
+export type { JsonCmsApi, SchemaDoc, EntryDoc } from "./types.js";
+export type { SchemaId, EntryId } from "../client/index.js";
+
+// Framework-agnostic utilities
+export { inferSchemaFromData } from "./lib/infer-schema.js";
+export {
+  createDefaultUiSchema,
+  mergeUiSchemas,
+  DEFAULT_SUBMIT_BUTTON_OPTIONS,
+} from "./lib/ui-schema.js";
+export type {
+  UiSchema,
+  UiOptions,
+  UiSchemaSubmitButtonOptions,
+} from "./lib/ui-schema.js";

--- a/packages/json-cms/src/react/lib/infer-schema.ts
+++ b/packages/json-cms/src/react/lib/infer-schema.ts
@@ -1,0 +1,134 @@
+type InferredType =
+  | "string"
+  | "number"
+  | "integer"
+  | "boolean"
+  | "object"
+  | "array"
+  | "null"
+  | "mixed";
+
+function inferType(value: unknown): InferredType {
+  if (value === null || value === undefined) return "null";
+  if (typeof value === "boolean") return "boolean";
+  if (typeof value === "number") {
+    return Number.isInteger(value) ? "integer" : "number";
+  }
+  if (typeof value === "string") return "string";
+  if (Array.isArray(value)) return "array";
+  if (typeof value === "object") return "object";
+  return "string";
+}
+
+function mergeTypes(a: InferredType, b: InferredType): InferredType {
+  if (a === b) return a;
+  if (a === "null") return b;
+  if (b === "null") return a;
+  // integer + number → number
+  if ((a === "integer" && b === "number") || (a === "number" && b === "integer")) return "number";
+  return "mixed";
+}
+
+function inferObjectSchema(objects: Record<string, unknown>[]): Record<string, unknown> {
+  if (objects.length === 0) {
+    return { type: "object", title: "", description: "", properties: {}, required: [] };
+  }
+
+  // Collect all keys
+  const allKeys = new Set<string>();
+  for (const obj of objects) {
+    for (const key of Object.keys(obj)) {
+      allKeys.add(key);
+    }
+  }
+
+  const properties: Record<string, unknown> = {};
+  const required: string[] = [];
+
+  for (const key of allKeys) {
+    // Determine the inferred type across all objects
+    let inferredType: InferredType = "null";
+    let presentCount = 0;
+    const subObjects: Record<string, unknown>[] = [];
+    const arrayValues: unknown[][] = [];
+
+    for (const obj of objects) {
+      if (key in obj && obj[key] !== undefined && obj[key] !== null) {
+        presentCount++;
+        const t = inferType(obj[key]);
+        inferredType = mergeTypes(inferredType, t);
+        if (t === "object" && obj[key] !== null) {
+          subObjects.push(obj[key] as Record<string, unknown>);
+        }
+        if (t === "array" && Array.isArray(obj[key])) {
+          arrayValues.push(obj[key] as unknown[]);
+        }
+      }
+    }
+
+    // Build the property schema
+    let propSchema: Record<string, unknown> = {};
+
+    if (inferredType !== "mixed" && inferredType !== "null") {
+      if (inferredType === "object" && subObjects.length > 0) {
+        const nested = inferObjectSchema(subObjects);
+        propSchema = nested;
+        // Override type explicitly
+        propSchema.type = "object";
+      } else if (inferredType === "array") {
+        propSchema = { type: "array" };
+        // Try to infer item type from all array values
+        const flatItems = arrayValues.flat();
+        if (flatItems.length > 0) {
+          let itemType: InferredType = "null";
+          for (const item of flatItems) {
+            itemType = mergeTypes(itemType, inferType(item));
+          }
+          if (itemType !== "mixed" && itemType !== "null") {
+            propSchema.items = { type: itemType };
+          }
+        }
+      } else {
+        propSchema = { type: inferredType };
+      }
+    }
+
+    properties[key] = propSchema;
+
+    // Mark as required if present in all objects and never null
+    if (presentCount === objects.length) {
+      required.push(key);
+    }
+  }
+
+  return {
+    type: "object",
+    title: "",
+    description: "",
+    properties,
+    ...(required.length > 0 ? { required } : {}),
+  };
+}
+
+/**
+ * Infer a JSON Schema Draft-07 object from an array of plain objects.
+ * The resulting schema will have empty title and description that the user
+ * should fill in before saving.
+ */
+export function inferSchemaFromData(data: unknown[]): Record<string, unknown> {
+  const objects = data.filter(
+    (item): item is Record<string, unknown> =>
+      typeof item === "object" && item !== null && !Array.isArray(item),
+  );
+
+  if (objects.length === 0) {
+    return {
+      type: "object",
+      title: "",
+      description: "",
+      properties: {},
+    };
+  }
+
+  return inferObjectSchema(objects);
+}

--- a/packages/json-cms/src/react/lib/ui-schema.ts
+++ b/packages/json-cms/src/react/lib/ui-schema.ts
@@ -1,0 +1,133 @@
+/**
+ * RJSF UiSchema type definitions
+ * Based on https://rjsf-team.github.io/react-jsonschema-form/docs/api-reference/uiSchema
+ */
+
+/**
+ * Options for the submit button
+ * @see https://rjsf-team.github.io/react-jsonschema-form/docs/api-reference/uiSchema#submitbuttonoptions
+ */
+export interface UiSchemaSubmitButtonOptions {
+  /** The text of the submit button. Set to "Submit" by default */
+  submitText?: string;
+  /** Flag, if `true`, removes the submit button completely from the form */
+  norender?: boolean;
+  /** Any other props to be passed to the submit button itself */
+  props?: {
+    /** A boolean value stating if the submit button is disabled */
+    disabled?: boolean;
+    /** The class name for the submit button */
+    className?: string;
+    [key: string]: unknown;
+  };
+}
+
+/**
+ * Options that can be provided to `ui:options`
+ * @see https://rjsf-team.github.io/react-jsonschema-form/docs/api-reference/uiSchema#uioptions
+ */
+export interface UiOptions {
+  /** Label text for the field */
+  label?: boolean | string;
+  /** Title text for the field */
+  title?: string;
+  /** Description text for the field */
+  description?: string;
+  /** Placeholder text */
+  placeholder?: string;
+  /** Help text */
+  help?: string;
+  /** Whether the field is disabled */
+  disabled?: boolean;
+  /** Whether the field is readonly */
+  readonly?: boolean;
+  /** Whether to hide the error message */
+  hideError?: boolean;
+  /** Whether to show the label */
+  hideLabel?: boolean;
+  /** Widget-specific props */
+  [key: string]: unknown;
+}
+
+/**
+ * The UiSchema for a single field or the entire form
+ * @see https://rjsf-team.github.io/react-jsonschema-form/docs/api-reference/uiSchema
+ */
+export interface UiSchema {
+  /** Global options that apply to all fields */
+  "ui:globalOptions"?: UiOptions;
+  /** Submit button configuration */
+  "ui:submitButtonOptions"?: UiSchemaSubmitButtonOptions;
+  /** Widget to use for this field */
+  "ui:widget"?: string;
+  /** Field component to use */
+  "ui:field"?: string;
+  /** Options for the widget/field */
+  "ui:options"?: UiOptions;
+  /** Whether to autofocus this field */
+  "ui:autofocus"?: boolean;
+  /** Whether the field is disabled */
+  "ui:disabled"?: boolean;
+  /** Whether the field is readonly */
+  "ui:readonly"?: boolean;
+  /** Whether to hide the error message */
+  "ui:hideError"?: boolean;
+  /** Placeholder text */
+  "ui:placeholder"?: string;
+  /** Help text */
+  "ui:help"?: string;
+  /** Title text */
+  "ui:title"?: string;
+  /** Description text */
+  "ui:description"?: string;
+  /** Enum names for select/radio options */
+  "ui:enumNames"?: string[];
+  /** Order of fields (for objects) */
+  "ui:order"?: string[];
+  /** Whether to enable adding items (for arrays) */
+  "ui:addable"?: boolean;
+  /** Whether to enable removing items (for arrays) */
+  "ui:removable"?: boolean;
+  /** Whether to enable ordering items (for arrays) */
+  "ui:orderable"?: boolean;
+  /** Whether to copy array items */
+  "ui:copyable"?: boolean;
+  /** Nested UiSchema for object properties */
+  [property: string]: unknown;
+}
+
+/**
+ * Default submit button options
+ */
+export const DEFAULT_SUBMIT_BUTTON_OPTIONS: UiSchemaSubmitButtonOptions = {
+  submitText: "Submit",
+  norender: false,
+  props: {
+    disabled: false,
+  },
+};
+
+/**
+ * Create a default UiSchema with submit button options
+ */
+export function createDefaultUiSchema(
+  options?: Partial<UiSchemaSubmitButtonOptions>
+): UiSchema {
+  return {
+    "ui:submitButtonOptions": {
+      ...DEFAULT_SUBMIT_BUTTON_OPTIONS,
+      ...options,
+    },
+  };
+}
+
+/**
+ * Merge multiple UiSchema objects together
+ * Later schemas take precedence
+ */
+export function mergeUiSchemas(...schemas: (UiSchema | undefined)[]): UiSchema {
+  return schemas.reduce<UiSchema>((acc, schema) => {
+    if (!schema) return acc;
+    return { ...acc, ...schema };
+  }, {});
+}

--- a/packages/json-cms/src/react/provider.tsx
+++ b/packages/json-cms/src/react/provider.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import type { ReactNode } from "react";
+import type { JsonCmsApi } from "./types.js";
+
+const JsonCmsContext = createContext<JsonCmsApi | null>(null);
+
+/**
+ * Provides the JSON CMS function references to the hooks in this package.
+ *
+ * Wrap your app (inside your Convex provider) and pass the functions your
+ * app exposes for the component:
+ *
+ * ```tsx
+ * import { JsonCmsProvider } from "@caden/json-cms/react";
+ * import { api } from "../convex/_generated/api";
+ *
+ * <JsonCmsProvider
+ *   api={{
+ *     listSchemas: api.schemas.list,
+ *     getSchema: api.schemas.get,
+ *     createSchema: api.schemas.create,
+ *     updateSchema: api.schemas.update,
+ *     deleteSchema: api.schemas.remove,
+ *     listEntries: api.entries.list,
+ *     getEntry: api.entries.get,
+ *     createEntry: api.entries.create,
+ *     createEntriesBulk: api.entries.createBulk,
+ *     updateEntry: api.entries.update,
+ *     deleteEntry: api.entries.remove,
+ *     deleteEntriesBySchema: api.entries.removeBySchema,
+ *   }}
+ * >
+ *   {children}
+ * </JsonCmsProvider>
+ * ```
+ */
+export function JsonCmsProvider({ api, children }: { api: JsonCmsApi; children: ReactNode }) {
+  return <JsonCmsContext.Provider value={api}>{children}</JsonCmsContext.Provider>;
+}
+
+/**
+ * Access the JSON CMS function references from context. Throws if used
+ * outside of a `<JsonCmsProvider>`.
+ */
+export function useJsonCmsApi(): JsonCmsApi {
+  const api = useContext(JsonCmsContext);
+  if (!api) {
+    throw new Error("useJsonCmsApi must be used within a <JsonCmsProvider>.");
+  }
+  return api;
+}

--- a/packages/json-cms/src/react/types.ts
+++ b/packages/json-cms/src/react/types.ts
@@ -1,0 +1,52 @@
+import type { FunctionReference } from "convex/server";
+import type { SchemaId, EntryId } from "../client/index.js";
+
+/**
+ * A stored JSON schema document, as returned by the component's queries.
+ */
+export type SchemaDoc = {
+  _id: SchemaId;
+  _creationTime: number;
+  title: string;
+  description: string;
+  /** JSON Schema object. */
+  schema: unknown;
+  /** Optional RJSF UI schema object. */
+  uiSchema?: unknown;
+};
+
+/**
+ * A stored data entry document, as returned by the component's queries.
+ */
+export type EntryDoc = {
+  _id: EntryId;
+  _creationTime: number;
+  schemaId: SchemaId;
+  /** Entry data conforming to the referenced schema. */
+  data: unknown;
+};
+
+/**
+ * The set of function references a host app exposes for the JSON CMS
+ * component (via `exposeApi`). Map your app's exposed functions to this
+ * shape and hand it to `<JsonCmsProvider api={...} />`.
+ *
+ * The references are intentionally loosely typed here so that any app's
+ * generated function references are assignable regardless of how their
+ * `Id` types are branded. The hooks re-apply the concrete `SchemaDoc` /
+ * `EntryDoc` result types on top.
+ */
+export interface JsonCmsApi {
+  listSchemas: FunctionReference<"query">;
+  getSchema: FunctionReference<"query">;
+  createSchema: FunctionReference<"mutation">;
+  updateSchema: FunctionReference<"mutation">;
+  deleteSchema: FunctionReference<"mutation">;
+  listEntries: FunctionReference<"query">;
+  getEntry: FunctionReference<"query">;
+  createEntry: FunctionReference<"mutation">;
+  createEntriesBulk: FunctionReference<"mutation">;
+  updateEntry: FunctionReference<"mutation">;
+  deleteEntry: FunctionReference<"mutation">;
+  deleteEntriesBySchema: FunctionReference<"mutation">;
+}


### PR DESCRIPTION
## Summary

Builds out the component's React layer (`@caden/json-cms/react`) — the hooks + low-level utilities half of the batteries-included React work. Styled `react/ui` components follow in the next PR.

Because a host app owns the component's exposed functions (it re-exports them via `exposeApi`), the hooks can't hard-code function references. Instead:

- **`JsonCmsProvider`** takes a map of the app's exposed refs once and puts them in context.
- **Typed hooks** read from context: `useSchemas`, `useSchema`, `useEntries`, `useEntry`, and `useCreateSchema` / `useUpdateSchema` / `useDeleteSchema` / `useCreateEntry` / `useCreateEntriesBulk` / `useUpdateEntry` / `useDeleteEntry` / `useDeleteEntriesBySchema`.
- Provider refs are loosely typed (`FunctionReference<"query"|"mutation">`) so any app's generated references are assignable regardless of `Id` branding; the hooks re-apply concrete `SchemaDoc` / `EntryDoc` result types and typed mutation-arg signatures on top.

Also ships **framework-agnostic utilities** re-exported from the same entrypoint: `inferSchemaFromData` (JSON Schema inference from sample data) and the `UiSchema` types + `createDefaultUiSchema` / `mergeUiSchemas` helpers (ported from the app), plus the `SchemaId` / `EntryId` types.

## Files
- `packages/json-cms/src/react/{provider.tsx,hooks.ts,types.ts,index.ts}`
- `packages/json-cms/src/react/lib/{infer-schema.ts,ui-schema.ts}`

The `./react` package export already existed and now resolves to real code.

## Stack
This continues the restructure stack; base is `docs/reconcile-plan`. Merge that stack first.

## Verification
- `bun run build` — clean; emits `dist/react/index.js` + `.d.ts`
- `bun run test` — **32 passing**
- `bun run lint` — 0 errors (one benign `react-refresh/only-export-components` warning on the provider file)

## Follow-up
- `react/ui` styled components (`SchemaEditor`, `EntryForm` via `@rjsf`, `SchemaList`) + `./react/ui` export, wired into the component's `example/`.
- Migrate `app/` to consume `@caden/json-cms/react` instead of local hooks.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHpgFbYdFnDGNdUqvig14P)_