### PR TITLE
feat(json-cms): add styled react/ui components

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,11 +76,31 @@
     "packages/json-cms": {
       "name": "@caden/json-cms",
       "version": "0.1.0",
+      "dependencies": {
+        "@base-ui/react": "^1.2.0",
+        "@codemirror/autocomplete": "^6.20.1",
+        "@codemirror/lang-json": "^6.0.2",
+        "@codemirror/language": "^6.12.2",
+        "@codemirror/lint": "^6.9.5",
+        "@rjsf/core": "^6.4.1",
+        "@rjsf/shadcn": "^6.4.1",
+        "@rjsf/utils": "^6.4.1",
+        "@rjsf/validator-ajv8": "^6.4.1",
+        "@uiw/codemirror-theme-github": "^4.25.8",
+        "@uiw/react-codemirror": "^4.25.8",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "codemirror-json-schema": "^0.8.1",
+        "lucide-react": "^0.577.0",
+        "sonner": "^2.0.7",
+        "tailwind-merge": "^3.5.0",
+      },
       "devDependencies": {
         "@convex-dev/eslint-plugin": "^1.1.1",
         "@edge-runtime/vm": "^5.0.0",
         "@eslint/eslintrc": "^3.3.5",
         "@eslint/js": "9.39.4",
+        "@types/json-schema": "^7.0.15",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -1237,7 +1257,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.20.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ=="],
 
-    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
@@ -2497,8 +2517,6 @@
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
-    "markdown-it/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
-
     "meow/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
@@ -2522,6 +2540,8 @@
     "oxc-parser/@oxc-project/types": ["@oxc-project/types@0.120.0", "", {}, "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg=="],
 
     "parse-json/json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 

--- a/packages/json-cms/package.json
+++ b/packages/json-cms/package.json
@@ -49,6 +49,11 @@
       "types": "./dist/react/index.d.ts",
       "default": "./dist/react/index.js"
     },
+    "./react/ui": {
+      "types": "./dist/react/ui/index.d.ts",
+      "default": "./dist/react/ui/index.js"
+    },
+    "./react/ui/styles.css": "./src/react/ui/styles.css",
     "./test": "./src/test.ts",
     "./_generated/component.js": {
       "types": "./dist/component/_generated/component.d.ts"
@@ -69,11 +74,31 @@
     "convex": "^1.32.0",
     "react": "^18.3.1 || ^19.0.0"
   },
+  "dependencies": {
+    "@base-ui/react": "^1.2.0",
+    "@codemirror/autocomplete": "^6.20.1",
+    "@codemirror/lang-json": "^6.0.2",
+    "@codemirror/language": "^6.12.2",
+    "@codemirror/lint": "^6.9.5",
+    "@rjsf/core": "^6.4.1",
+    "@rjsf/shadcn": "^6.4.1",
+    "@rjsf/utils": "^6.4.1",
+    "@rjsf/validator-ajv8": "^6.4.1",
+    "@uiw/codemirror-theme-github": "^4.25.8",
+    "@uiw/react-codemirror": "^4.25.8",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "codemirror-json-schema": "^0.8.1",
+    "lucide-react": "^0.577.0",
+    "sonner": "^2.0.7",
+    "tailwind-merge": "^3.5.0"
+  },
   "devDependencies": {
     "@convex-dev/eslint-plugin": "^1.1.1",
     "@edge-runtime/vm": "^5.0.0",
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "9.39.4",
+    "@types/json-schema": "^7.0.15",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/packages/json-cms/src/react/ui/entry-form.tsx
+++ b/packages/json-cms/src/react/ui/entry-form.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import Form from "@rjsf/shadcn";
+import validator from "@rjsf/validator-ajv8";
+import type { IChangeEvent } from "@rjsf/core";
+import { mergeUiSchemas, type UiSchema } from "../lib/ui-schema.js";
+
+export interface EntryFormProps {
+  /** JSON Schema describing the entry's shape. */
+  schema: object;
+  /** Optional RJSF UI schema (e.g. loaded from a `SchemaDoc.uiSchema`). */
+  uiSchema?: object;
+  /** Initial/controlled form data. */
+  formData?: unknown;
+  /** Disables all fields and the submit button, e.g. while saving. */
+  disabled?: boolean;
+  /** Label for the submit button. Defaults to "Submit". */
+  submitText?: string;
+  /** Called with the submitted form data. */
+  onSubmit: (data: unknown) => void | Promise<void>;
+}
+
+/**
+ * A thin, reusable RJSF form for creating/editing CMS entries against a
+ * stored JSON schema. Renders with `@rjsf/shadcn` for styling consistent
+ * with the rest of `react/ui`.
+ */
+export function EntryForm({
+  schema,
+  uiSchema,
+  formData,
+  disabled = false,
+  submitText = "Submit",
+  onSubmit,
+}: EntryFormProps) {
+  const mergedUiSchema: UiSchema = mergeUiSchemas(uiSchema as UiSchema | undefined, {
+    "ui:submitButtonOptions": {
+      submitText,
+      norender: false,
+      props: {
+        disabled,
+      },
+    },
+  });
+
+  const handleSubmit = (data: IChangeEvent) => {
+    return onSubmit(data.formData);
+  };
+
+  return (
+    <Form
+      schema={schema}
+      uiSchema={mergedUiSchema as any}
+      validator={validator}
+      formData={formData}
+      disabled={disabled}
+      onSubmit={handleSubmit}
+    />
+  );
+}

--- a/packages/json-cms/src/react/ui/index.ts
+++ b/packages/json-cms/src/react/ui/index.ts
@@ -1,0 +1,33 @@
+"use client";
+
+// Schema editor family
+export { SchemaEditor } from "./schema-editor.js";
+export { VisualBuilder } from "./visual-builder.js";
+export type { PropertyType, PropertyDef, SchemaFormData } from "./visual-builder.js";
+export { ValidationPane } from "./validation-pane.js";
+export type { ValidationState, ValidationResult } from "./validation-pane.js";
+export { SchemaPreview } from "./schema-preview.js";
+export { JsonTree } from "./json-tree.js";
+
+// New batteries-included components
+export { EntryForm } from "./entry-form.js";
+export type { EntryFormProps } from "./entry-form.js";
+export { SchemaList } from "./schema-list.js";
+export type { SchemaListProps } from "./schema-list.js";
+
+// Primitives
+export { Button, buttonVariants } from "./primitives/button.js";
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+} from "./primitives/card.js";
+export { ConfirmDialog } from "./primitives/dialog.js";
+export { Input } from "./primitives/input.js";
+export { Label } from "./primitives/label.js";
+export { Textarea } from "./primitives/textarea.js";
+export { JsonEditor } from "./primitives/json-editor.js";

--- a/packages/json-cms/src/react/ui/json-tree.tsx
+++ b/packages/json-cms/src/react/ui/json-tree.tsx
@@ -1,0 +1,135 @@
+import { cn } from "./lib/utils.js";
+
+interface JsonTreeProps {
+  data: unknown;
+  /** Set of AJV instancePaths that are failing, e.g. "/email", "/address/city" */
+  failingPaths: Set<string>;
+  /** Map of AJV instancePath → human-readable error message */
+  errors: Map<string, string>;
+  /** Set of paths for fields that exist in the data but are not in the schema's properties */
+  unknownPaths?: Set<string>;
+  path?: string;
+  depth?: number;
+}
+
+function formatPrimitive(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value === "string") return `"${value}"`;
+  return String(value);
+}
+
+function primitiveColor(value: unknown): string {
+  if (value === null) return "text-muted-foreground";
+  if (typeof value === "boolean") return "text-blue-600 dark:text-blue-400";
+  if (typeof value === "number") return "text-emerald-600 dark:text-emerald-400";
+  return "text-amber-600 dark:text-amber-400";
+}
+
+export function JsonTree({
+  data,
+  failingPaths,
+  errors,
+  unknownPaths,
+  path = "",
+  depth = 0,
+}: JsonTreeProps) {
+  const indent = depth * 12;
+
+  if (Array.isArray(data)) {
+    if (data.length === 0) return <span className="text-muted-foreground text-xs">[]</span>;
+    return (
+      <div>
+        {data.map((item, i) => {
+          const itemPath = `${path}/${i}`;
+          return (
+            <div key={i} style={{ marginLeft: indent > 0 ? 0 : undefined }}>
+              <span className="text-muted-foreground text-xs mr-1">{i}:</span>
+              <JsonTree
+                data={item}
+                failingPaths={failingPaths}
+                errors={errors}
+                unknownPaths={unknownPaths}
+                path={itemPath}
+                depth={depth + 1}
+              />
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  if (typeof data === "object" && data !== null) {
+    const entries = Object.entries(data as Record<string, unknown>);
+    if (entries.length === 0) return <span className="text-muted-foreground text-xs">{"{}"}</span>;
+    return (
+      <div className="space-y-0.5">
+        {entries.map(([key, value]) => {
+          const keyPath = `${path}/${key}`;
+          const isFailing = failingPaths.has(keyPath);
+          const isUnknown = unknownPaths?.has(keyPath) ?? false;
+          const errorMsg = errors.get(keyPath);
+
+          return (
+            <div key={key} style={{ marginLeft: depth * 12 }}>
+              <div
+                className={cn(
+                  "flex items-start gap-1 rounded px-1 py-0.5 text-xs font-mono",
+                  isFailing && "bg-destructive/10",
+                  isUnknown && !isFailing && "bg-muted/60",
+                )}
+              >
+                <span
+                  className={cn(
+                    "font-medium shrink-0",
+                    isFailing
+                      ? "text-destructive"
+                      : isUnknown
+                        ? "text-muted-foreground italic"
+                        : "text-foreground",
+                  )}
+                >
+                  {key}:
+                </span>
+                {typeof value === "object" && value !== null ? (
+                  <div className="min-w-0">
+                    <JsonTree
+                      data={value}
+                      failingPaths={failingPaths}
+                      errors={errors}
+                      unknownPaths={unknownPaths}
+                      path={keyPath}
+                      depth={depth + 1}
+                    />
+                  </div>
+                ) : (
+                  <span className={cn(isUnknown ? "text-muted-foreground" : primitiveColor(value), "truncate")}>
+                    {formatPrimitive(value)}
+                  </span>
+                )}
+                {isUnknown && (
+                  <span className="ml-auto shrink-0 text-[10px] text-muted-foreground font-sans italic">
+                    not in schema
+                  </span>
+                )}
+              </div>
+              {isFailing && errorMsg && (
+                <div
+                  style={{ marginLeft: depth * 12 + 4 }}
+                  className="text-[10px] text-destructive px-1 pb-0.5 leading-tight"
+                >
+                  {errorMsg}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  // Primitive at root level
+  return (
+    <span className={cn("text-xs font-mono", primitiveColor(data))}>{formatPrimitive(data)}</span>
+  );
+}

--- a/packages/json-cms/src/react/ui/lib/use-color-scheme.ts
+++ b/packages/json-cms/src/react/ui/lib/use-color-scheme.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+
+export function useColorScheme(): "light" | "dark" {
+  const [isDark, setIsDark] = useState(() => document.documentElement.classList.contains("dark"));
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setIsDark(document.documentElement.classList.contains("dark"));
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  return isDark ? "dark" : "light";
+}

--- a/packages/json-cms/src/react/ui/lib/utils.ts
+++ b/packages/json-cms/src/react/ui/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/packages/json-cms/src/react/ui/primitives/button.tsx
+++ b/packages/json-cms/src/react/ui/primitives/button.tsx
@@ -1,0 +1,56 @@
+import { Button as ButtonPrimitive } from "@base-ui/react/button";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "../lib/utils.js";
+
+const buttonVariants = cva(
+  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-xs/relaxed font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/80",
+        outline:
+          "border-border hover:bg-input/50 hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:bg-input/30",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+        ghost:
+          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+        destructive:
+          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default:
+          "h-7 gap-1 px-2 text-xs/relaxed has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        xs: "h-5 gap-1 rounded-sm px-2 text-[0.625rem] has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-2.5",
+        sm: "h-6 gap-1 px-2 text-xs/relaxed has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        lg: "h-8 gap-1 px-2.5 text-xs/relaxed has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 [&_svg:not([class*='size-'])]:size-4",
+        icon: "size-7 [&_svg:not([class*='size-'])]:size-3.5",
+        "icon-xs": "size-5 rounded-sm [&_svg:not([class*='size-'])]:size-2.5",
+        "icon-sm": "size-6 [&_svg:not([class*='size-'])]:size-3",
+        "icon-lg": "size-8 [&_svg:not([class*='size-'])]:size-4",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function Button({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+  return (
+    <ButtonPrimitive
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Button, buttonVariants };

--- a/packages/json-cms/src/react/ui/primitives/card.tsx
+++ b/packages/json-cms/src/react/ui/primitives/card.tsx
@@ -1,0 +1,83 @@
+import * as React from "react";
+
+import { cn } from "../lib/utils.js";
+
+function Card({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        "group/card flex flex-col gap-4 overflow-hidden rounded-lg bg-card py-4 text-xs/relaxed text-card-foreground ring-1 ring-foreground/10 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 *:[img:first-child]:rounded-t-lg *:[img:last-child]:rounded-b-lg",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-lg px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return <div data-slot="card-title" className={cn("text-sm font-medium", className)} {...props} />;
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-xs/relaxed text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn("col-start-2 row-span-2 row-start-1 self-start justify-self-end", className)}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-4 group-data-[size=sm]/card:px-3", className)}
+      {...props}
+    />
+  );
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        "flex items-center rounded-b-lg px-4 group-data-[size=sm]/card:px-3 [.border-t]:pt-4 group-data-[size=sm]/card:[.border-t]:pt-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent };

--- a/packages/json-cms/src/react/ui/primitives/dialog.tsx
+++ b/packages/json-cms/src/react/ui/primitives/dialog.tsx
@@ -1,0 +1,74 @@
+import { Dialog } from "@base-ui/react/dialog";
+import { cn } from "../lib/utils.js";
+
+function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  onConfirm,
+  destructive = false,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  destructive?: boolean;
+}) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/40 backdrop-blur-sm data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 transition-opacity duration-150" />
+        <Dialog.Popup
+          className={cn(
+            "fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2",
+            "bg-background border border-border rounded-lg shadow-lg p-6",
+            "data-[ending-style]:opacity-0 data-[starting-style]:opacity-0",
+            "data-[ending-style]:scale-95 data-[starting-style]:scale-95",
+            "transition-all duration-150",
+          )}
+        >
+          <Dialog.Title className="text-base font-semibold text-foreground mb-2">
+            {title}
+          </Dialog.Title>
+          {description && (
+            <Dialog.Description className="text-sm text-muted-foreground mb-6">
+              {description}
+            </Dialog.Description>
+          )}
+          <div className="flex justify-end gap-2">
+            <Dialog.Close
+              className={cn(
+                "inline-flex items-center justify-center rounded-md border border-border px-3 h-7 text-xs font-medium",
+                "bg-background hover:bg-muted transition-colors",
+              )}
+            >
+              {cancelLabel}
+            </Dialog.Close>
+            <button
+              onClick={() => {
+                onConfirm();
+                onOpenChange(false);
+              }}
+              className={cn(
+                "inline-flex items-center justify-center rounded-md px-3 h-7 text-xs font-medium transition-colors",
+                destructive
+                  ? "bg-destructive/10 text-destructive hover:bg-destructive/20 border border-destructive/30"
+                  : "bg-primary text-primary-foreground hover:bg-primary/80",
+              )}
+            >
+              {confirmLabel}
+            </button>
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+export { ConfirmDialog };

--- a/packages/json-cms/src/react/ui/primitives/input.tsx
+++ b/packages/json-cms/src/react/ui/primitives/input.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { Input as InputPrimitive } from "@base-ui/react/input";
+
+import { cn } from "../lib/utils.js";
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <InputPrimitive
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-7 w-full min-w-0 rounded-md border border-input bg-input/20 px-2 py-0.5 text-sm transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-xs/relaxed file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 md:text-xs/relaxed dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };

--- a/packages/json-cms/src/react/ui/primitives/json-editor.tsx
+++ b/packages/json-cms/src/react/ui/primitives/json-editor.tsx
@@ -1,0 +1,174 @@
+import { useMemo, useRef, useEffect } from "react";
+import ReactCodeMirror, { EditorView } from "@uiw/react-codemirror";
+import { githubLight, githubDark } from "@uiw/codemirror-theme-github";
+import { json } from "@codemirror/lang-json";
+import { linter, lintGutter, type Diagnostic } from "@codemirror/lint";
+import { syntaxTree } from "@codemirror/language";
+import { jsonSchemaLinter, stateExtensions, updateSchema } from "codemirror-json-schema";
+import type { JSONSchema7 } from "json-schema";
+import { useColorScheme } from "../lib/use-color-scheme.js";
+import { cn } from "../lib/utils.js";
+
+const jsonLinter = linter((view): Diagnostic[] => {
+  const diagnostics: Diagnostic[] = [];
+  const doc = view.state.doc.toString();
+
+  if (!doc.trim()) return diagnostics;
+
+  // Surface parse errors from the lezer syntax tree
+  syntaxTree(view.state)
+    .cursor()
+    .iterate((node) => {
+      if (node.type.isError) {
+        diagnostics.push({
+          from: node.from,
+          to: Math.max(node.to, node.from + 1),
+          severity: "error",
+          message: "JSON syntax error",
+        });
+      }
+    });
+
+  if (diagnostics.length > 0) return diagnostics;
+
+  // Semantic validation (title / description)
+  try {
+    const parsed = JSON.parse(doc);
+
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      diagnostics.push({
+        from: 0,
+        to: doc.length,
+        severity: "error",
+        message: "Schema must be a JSON object",
+      });
+      return diagnostics;
+    }
+
+    const obj = parsed as Record<string, unknown>;
+
+    if (!obj.title || typeof obj.title !== "string" || !obj.title.trim()) {
+      diagnostics.push({
+        from: 0,
+        to: doc.length,
+        severity: "warning",
+        message: 'Schema must have a non-empty "title" property',
+      });
+    }
+
+    if (!obj.description || typeof obj.description !== "string" || !obj.description.trim()) {
+      diagnostics.push({
+        from: 0,
+        to: doc.length,
+        severity: "warning",
+        message: 'Schema must have a non-empty "description" property',
+      });
+    }
+  } catch {
+    // parse errors already surfaced via syntax tree above
+  }
+
+  return diagnostics;
+});
+
+// Blend CodeMirror's internals with the site's design tokens
+const baseTheme = EditorView.theme({
+  "&": {
+    fontSize: "0.875rem",
+    fontFamily:
+      'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+  },
+  ".cm-scroller": { overflow: "auto" },
+  ".cm-gutters": { borderRight: "1px solid var(--border)" },
+  ".cm-lineNumbers .cm-gutterElement": { minWidth: "2.5rem", paddingRight: "0.5rem" },
+});
+
+interface JsonEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  onBlur?: () => void;
+  placeholder?: string;
+  height?: string;
+  /** Suppress the meta-schema linter that checks for object/title/description. Use on data editors. */
+  disableSchemaLinting?: boolean;
+  /** When provided, validate the editor content against this JSON Schema using codemirror-json-schema. */
+  jsonSchema?: object;
+  "aria-describedby"?: string;
+  "aria-labelledby"?: string;
+}
+
+export function JsonEditor({
+  value,
+  onChange,
+  onBlur,
+  placeholder,
+  height = "256px",
+  disableSchemaLinting = false,
+  jsonSchema,
+  "aria-describedby": ariaDescribedBy,
+  "aria-labelledby": ariaLabelledBy,
+}: JsonEditorProps) {
+  const colorScheme = useColorScheme();
+  const viewRef = useRef<EditorView | null>(null);
+  const enableJsonSchemaLinting = jsonSchema !== undefined;
+
+  // Update the schema in CodeMirror state whenever it changes
+  useEffect(() => {
+    if (viewRef.current) {
+      updateSchema(viewRef.current, jsonSchema as JSONSchema7 | undefined);
+    }
+  }, [jsonSchema]);
+
+  const extensions = useMemo(
+    () => [
+      json(),
+      lintGutter(),
+      ...(disableSchemaLinting ? [] : [jsonLinter]),
+      // Add schema-based linting extensions (schema value pushed separately via updateSchema)
+      ...(enableJsonSchemaLinting ? [...stateExtensions(), linter(jsonSchemaLinter())] : []),
+      baseTheme,
+      EditorView.contentAttributes.of({
+        ...(ariaDescribedBy ? { "aria-describedby": ariaDescribedBy } : {}),
+        ...(ariaLabelledBy ? { "aria-labelledby": ariaLabelledBy } : {}),
+      }),
+    ],
+    [ariaDescribedBy, ariaLabelledBy, disableSchemaLinting, enableJsonSchemaLinting],
+  );
+
+  return (
+    <div
+      className={cn(
+        "rounded-md border border-input overflow-hidden",
+        "focus-within:outline-none focus-within:ring-2 focus-within:ring-ring",
+      )}
+    >
+      <ReactCodeMirror
+        value={value}
+        onChange={onChange}
+        onBlur={onBlur}
+        height={height}
+        theme={colorScheme === "dark" ? githubDark : githubLight}
+        extensions={extensions}
+        placeholder={placeholder}
+        onCreateEditor={(view) => {
+          viewRef.current = view;
+          // Set schema immediately on mount so first validation is instant
+          if (jsonSchema !== undefined) {
+            updateSchema(view, jsonSchema as JSONSchema7);
+          }
+        }}
+        basicSetup={{
+          lineNumbers: true,
+          foldGutter: false,
+          dropCursor: false,
+          allowMultipleSelections: false,
+          indentOnInput: true,
+          closeBrackets: true,
+          autocompletion: false,
+          highlightActiveLine: false,
+          highlightActiveLineGutter: false,
+        }}
+      />
+    </div>
+  );
+}

--- a/packages/json-cms/src/react/ui/primitives/label.tsx
+++ b/packages/json-cms/src/react/ui/primitives/label.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+import { cn } from "../lib/utils.js";
+
+function Label({ className, ...props }: React.ComponentProps<"label">) {
+  return (
+    <label
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-xs/relaxed leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Label };

--- a/packages/json-cms/src/react/ui/primitives/textarea.tsx
+++ b/packages/json-cms/src/react/ui/primitives/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+import { cn } from "../lib/utils.js";
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full resize-none rounded-md border border-input bg-input/20 px-2 py-2 text-sm transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 md:text-xs/relaxed dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/packages/json-cms/src/react/ui/schema-editor.tsx
+++ b/packages/json-cms/src/react/ui/schema-editor.tsx
@@ -1,0 +1,439 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+import { Save, Upload, FileJson, Code2, LayoutTemplate, AlertCircle } from "lucide-react";
+import { Button } from "./primitives/button.js";
+import { JsonEditor } from "./primitives/json-editor.js";
+import { ConfirmDialog } from "./primitives/dialog.js";
+import { cn } from "./lib/utils.js";
+import { inferSchemaFromData } from "../lib/infer-schema.js";
+import { toast } from "sonner";
+import { VisualBuilder } from "./visual-builder.js";
+import { ValidationPane, type ValidationState } from "./validation-pane.js";
+import { SchemaPreview } from "./schema-preview.js";
+
+const SCHEMA_SIZE_LIMIT = 102400; // 100 KB
+
+interface SchemaEditorProps {
+  initialJson?: string;
+  initialUiSchemaJson?: string;
+  onSave: (json: string, parsed: object, uiSchemaJson: string, uiSchemaParsed: object) => Promise<void>;
+  saveLabel?: string;
+}
+
+type PendingFile = { file: File; content: string; isDataArray: boolean };
+
+export function SchemaEditor({
+  initialJson = "",
+  initialUiSchemaJson = "",
+  onSave,
+  saveLabel = "Save",
+}: SchemaEditorProps) {
+  const [schemaJson, setSchemaJson] = useState(initialJson);
+  const [uiSchemaJson, setUiSchemaJson] = useState(initialUiSchemaJson);
+  const [activeTab, setActiveTab] = useState<"visual" | "code" | "data">("visual");
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Validation pane state (lifted for visual builder badges)
+  const [validationState, setValidationState] = useState<ValidationState>({
+    total: 0,
+    failingPaths: new Map(),
+  });
+  // External data to push into the validation pane. Wrapped in object so re-sending the same content still triggers the effect.
+  const [externalDataText, setExternalDataText] = useState<{ text: string } | undefined>(undefined);
+
+  // Drag & drop
+  const [isDraggingFile, setIsDraggingFile] = useState(false);
+  const [pendingFile, setPendingFile] = useState<PendingFile | null>(null);
+  const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
+  const uploadInputRef = useRef<HTMLInputElement>(null);
+  const dragLeaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const schemaBytes = new Blob([schemaJson]).size;
+  const isOverLimit = schemaBytes > SCHEMA_SIZE_LIMIT;
+
+  const getParseError = (): string | null => {
+    if (!schemaJson.trim()) return "Schema is required.";
+    try {
+      const p = JSON.parse(schemaJson);
+      if (typeof p !== "object" || p === null || Array.isArray(p))
+        return "Schema must be a JSON object.";
+      const obj = p as Record<string, unknown>;
+      if (!obj.title || typeof obj.title !== "string" || !obj.title.trim())
+        return "Schema must have a non-empty 'title' property.";
+      if (!obj.description || typeof obj.description !== "string" || !obj.description.trim())
+        return "Schema must have a non-empty 'description' property.";
+      return null;
+    } catch {
+      return "Invalid JSON — please check your input.";
+    }
+  };
+
+  // Document-level drag events for the full-page overlay
+  useEffect(() => {
+    const onDragEnter = (e: DragEvent) => {
+      if (e.dataTransfer?.types.includes("Files")) {
+        if (dragLeaveTimer.current) clearTimeout(dragLeaveTimer.current);
+        setIsDraggingFile(true);
+      }
+    };
+    const onDragLeave = () => {
+      dragLeaveTimer.current = setTimeout(() => setIsDraggingFile(false), 100);
+    };
+    const onDragOver = (e: DragEvent) => {
+      e.preventDefault();
+      if (e.dataTransfer?.types.includes("Files")) {
+        if (dragLeaveTimer.current) clearTimeout(dragLeaveTimer.current);
+        setIsDraggingFile(true);
+      }
+    };
+    const onDrop = (e: DragEvent) => {
+      e.preventDefault();
+      setIsDraggingFile(false);
+    };
+    document.addEventListener("dragenter", onDragEnter);
+    document.addEventListener("dragleave", onDragLeave);
+    document.addEventListener("dragover", onDragOver);
+    document.addEventListener("drop", onDrop);
+    return () => {
+      document.removeEventListener("dragenter", onDragEnter);
+      document.removeEventListener("dragleave", onDragLeave);
+      document.removeEventListener("dragover", onDragOver);
+      document.removeEventListener("drop", onDrop);
+    };
+  }, []);
+
+  const readFileAsText = (file: File): Promise<string> =>
+    new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = (e) => resolve((e.target?.result as string) ?? "");
+      reader.onerror = reject;
+      reader.readAsText(file);
+    });
+
+  const processFile = useCallback(
+    async (file: File) => {
+      if (!file.name.endsWith(".json") && file.type !== "application/json") {
+        toast.error("Please drop a .json file.");
+        return;
+      }
+      let content: string;
+      try {
+        content = await readFileAsText(file);
+      } catch {
+        toast.error("Could not read that file.");
+        return;
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(content);
+      } catch {
+        toast.error("That file does not contain valid JSON.");
+        return;
+      }
+
+      const isDataArray = Array.isArray(parsed);
+
+      if (isDataArray) {
+        // Data array — offer to infer schema or load into validation pane
+        if (schemaJson.trim()) {
+          setPendingFile({ file, content, isDataArray: true });
+          setIsConfirmDialogOpen(true);
+        } else {
+          // No schema yet — infer directly
+          const inferred = inferSchemaFromData(parsed as unknown[]);
+          setSchemaJson(JSON.stringify(inferred, null, 2));
+          toast.success(`Schema inferred from ${file.name}! Fill in title and description.`);
+        }
+      } else {
+        // It's a schema object
+        if (schemaJson.trim()) {
+          setPendingFile({ file, content, isDataArray: false });
+          setIsConfirmDialogOpen(true);
+        } else {
+          setSchemaJson(content);
+          toast.success(`Loaded schema from ${file.name}`);
+        }
+      }
+    },
+    [schemaJson],
+  );
+
+  const handleOverlayDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDraggingFile(false);
+    const file = e.dataTransfer.files[0];
+    if (file) processFile(file);
+  };
+
+  const handleConfirm = () => {
+    if (!pendingFile) return;
+    if (pendingFile.isDataArray) {
+      // Load into validation pane
+      setExternalDataText({ text: pendingFile.content });
+      toast.success(`Loaded ${pendingFile.file.name} into the validation pane.`);
+    } else {
+      setSchemaJson(pendingFile.content);
+      toast.success(`Replaced schema with ${pendingFile.file.name}`);
+    }
+    setPendingFile(null);
+  };
+
+  const handleSwitchToVisual = () => {
+    if (activeTab === "code") {
+      // Empty editor is fine — visual builder shows a blank canvas
+      if (!schemaJson.trim()) {
+        setActiveTab("visual");
+        return;
+      }
+      try {
+        JSON.parse(schemaJson);
+        setActiveTab("visual");
+      } catch {
+        toast.error("Fix the JSON syntax error before switching to Visual mode.");
+      }
+    }
+  };
+
+  const getUiSchemaParseError = (): string | null => {
+    if (!uiSchemaJson.trim()) return null;
+    try {
+      const parsed = JSON.parse(uiSchemaJson);
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        return "UI Schema must be a JSON object.";
+      }
+      return null;
+    } catch {
+      return "Invalid UI Schema JSON — please check your input.";
+    }
+  };
+
+  const uiSchemaBytes = new Blob([uiSchemaJson]).size;
+  const isUiSchemaOverLimit = uiSchemaBytes > SCHEMA_SIZE_LIMIT;
+
+  const handleSave = async () => {
+    const err = getParseError();
+    if (err) {
+      toast.error(err);
+      return;
+    }
+    if (isOverLimit) {
+      toast.error(`Schema exceeds the 100 KB limit (${Math.round(schemaBytes / 1024)} KB).`);
+      return;
+    }
+    const uiSchemaErr = getUiSchemaParseError();
+    if (uiSchemaErr) {
+      toast.error(uiSchemaErr);
+      return;
+    }
+    if (isUiSchemaOverLimit) {
+      toast.error(`UI Schema exceeds the 100 KB limit (${Math.round(uiSchemaBytes / 1024)} KB).`);
+      return;
+    }
+    setIsSaving(true);
+    try {
+      await onSave(
+        schemaJson,
+        JSON.parse(schemaJson) as object,
+        uiSchemaJson,
+        uiSchemaJson.trim() ? (JSON.parse(uiSchemaJson) as object) : {}
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const canSave = !getParseError() && !isOverLimit && !getUiSchemaParseError() && !isUiSchemaOverLimit;
+
+  return (
+    <div className="relative flex flex-col gap-4">
+      {/* Full-page drag overlay */}
+      {isDraggingFile && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center pointer-events-auto"
+          onDragOver={(e) => e.preventDefault()}
+          onDragLeave={() => setIsDraggingFile(false)}
+          onDrop={handleOverlayDrop}
+        >
+          <div className="absolute inset-2 bg-background/90 backdrop-blur-sm border-4 border-dashed border-primary rounded-xl" />
+          <div className="relative flex flex-col items-center gap-3 text-primary pointer-events-none">
+            <FileJson className="h-14 w-14" />
+            <p className="text-2xl font-semibold">Drop JSON file</p>
+            <p className="text-sm text-muted-foreground">Schema object or data array</p>
+          </div>
+        </div>
+      )}
+
+      {/* Replace/load confirmation dialog */}
+      <ConfirmDialog
+        open={isConfirmDialogOpen}
+        onOpenChange={setIsConfirmDialogOpen}
+        title={
+          pendingFile?.isDataArray
+            ? `Load "${pendingFile.file.name}" into validation pane?`
+            : `Replace schema with "${pendingFile?.file.name}"?`
+        }
+        description={
+          pendingFile?.isDataArray
+            ? "This file contains a JSON array of objects. It will be loaded into the validation pane so you can test it against your schema."
+            : "This will replace your current schema content."
+        }
+        confirmLabel={pendingFile?.isDataArray ? "Load into data pane" : "Replace"}
+        cancelLabel="Cancel"
+        destructive={!pendingFile?.isDataArray}
+        onConfirm={handleConfirm}
+      />
+
+      {/* Main two-panel layout */}
+      <div className="flex gap-4" style={{ minHeight: "600px" }}>
+        {/* Left panel: editor */}
+        <div className="flex flex-col flex-1 min-w-0 rounded-lg border border-border overflow-hidden">
+          {/* Toolbar */}
+          <div className="flex items-center gap-2 border-b border-border px-3 py-2 bg-muted/30 shrink-0">
+            {/* Mode tabs */}
+            <div className="flex rounded-md border border-border overflow-hidden">
+              <button
+                type="button"
+                onClick={handleSwitchToVisual}
+                className={cn(
+                  "flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium transition-colors",
+                  activeTab === "visual"
+                    ? "bg-background text-foreground"
+                    : "text-muted-foreground hover:text-foreground hover:bg-background/50",
+                )}
+              >
+                <LayoutTemplate className="h-3.5 w-3.5" />
+                Visual
+              </button>
+              <button
+                type="button"
+                onClick={() => setActiveTab("code")}
+                className={cn(
+                  "flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium transition-colors border-l border-border",
+                  activeTab === "code"
+                    ? "bg-background text-foreground"
+                    : "text-muted-foreground hover:text-foreground hover:bg-background/50",
+                )}
+              >
+                <Code2 className="h-3.5 w-3.5" />
+                Code
+              </button>
+              <button
+                type="button"
+                onClick={() => setActiveTab("data")}
+                className={cn(
+                  "flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium transition-colors border-l border-border",
+                  activeTab === "data"
+                    ? "bg-background text-foreground"
+                    : "text-muted-foreground hover:text-foreground hover:bg-background/50",
+                )}
+              >
+                <FileJson className="h-3.5 w-3.5" />
+                Data
+              </button>
+            </div>
+
+            <div className="flex-1" />
+
+            {/* Upload schema button */}
+            <input
+              ref={uploadInputRef}
+              type="file"
+              accept=".json,application/json"
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) processFile(file);
+                e.target.value = "";
+              }}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => uploadInputRef.current?.click()}
+            >
+              <Upload className="h-3.5 w-3.5 mr-1.5" />
+              Upload
+            </Button>
+
+            <Button type="button" size="sm" disabled={isSaving || !canSave} onClick={handleSave}>
+              <Save className="h-3.5 w-3.5 mr-1.5" />
+              {isSaving ? "Saving…" : saveLabel}
+            </Button>
+          </div>
+
+          {/* Size warnings */}
+          {(isOverLimit || isUiSchemaOverLimit) && (
+            <div className="flex flex-col gap-1 border-b border-destructive/30 bg-destructive/10 px-3 py-1.5 text-xs text-destructive shrink-0">
+              {isOverLimit && (
+                <div className="flex items-center gap-2">
+                  <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+                  Schema exceeds 100 KB limit ({Math.round(schemaBytes / 1024)} KB). Reduce its size
+                  before saving.
+                </div>
+              )}
+              {isUiSchemaOverLimit && (
+                <div className="flex items-center gap-2">
+                  <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+                  UI Schema exceeds 100 KB limit ({Math.round(uiSchemaBytes / 1024)} KB). Reduce its
+                  size before saving.
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Editor content */}
+          <div className="flex-1 overflow-auto p-4">
+            {activeTab === "visual" && (
+              <VisualBuilder
+                schemaJson={schemaJson}
+                onChange={setSchemaJson}
+                validationFailingPaths={validationState.failingPaths}
+                totalDataItems={validationState.total}
+              />
+            )}
+            {activeTab === "code" && (
+              <JsonEditor
+                value={schemaJson}
+                onChange={setSchemaJson}
+                placeholder={
+                  '{\n  "title": "My Schema",\n  "description": "...",\n  "type": "object",\n  "properties": {}\n}'
+                }
+                height="560px"
+              />
+            )}
+            {activeTab === "data" && (
+              <ValidationPane
+                schemaJson={schemaJson}
+                externalDataText={externalDataText}
+                onInferSchema={(inferredJson) => {
+                  setSchemaJson(inferredJson);
+                  toast.success("Schema inferred! Fill in title and description to finish.");
+                }}
+                onStateChange={setValidationState}
+              />
+            )}
+          </div>
+        </div>
+
+        {/* Right panel: UI Schema editor */}
+        <div className="w-80 xl:w-96 shrink-0 flex flex-col rounded-lg border border-border overflow-hidden">
+          <div className="flex items-center gap-2 border-b border-border px-3 py-2 bg-muted/30 shrink-0">
+            <span className="text-xs font-medium">UI Schema</span>
+          </div>
+          <div className="flex-1 overflow-auto">
+            <JsonEditor
+              value={uiSchemaJson}
+              onChange={setUiSchemaJson}
+              placeholder={'{\n  "ui:submitButtonOptions": {\n    "submitText": "Create Entry"\n  }\n}'}
+              height="540px"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Preview card - spans full width below the two panels */}
+      <SchemaPreview schemaJson={schemaJson} uiSchemaJson={uiSchemaJson} />
+    </div>
+  );
+}

--- a/packages/json-cms/src/react/ui/schema-list.tsx
+++ b/packages/json-cms/src/react/ui/schema-list.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useSchemas } from "../hooks.js";
+import type { SchemaId } from "../../client/index.js";
+import { Card, CardHeader, CardTitle, CardDescription } from "./primitives/card.js";
+
+export interface SchemaListProps {
+  /** Called with the clicked schema's id. */
+  onSelect?: (schemaId: SchemaId) => void;
+  /** Message shown when there are no schemas yet. */
+  emptyMessage?: string;
+}
+
+/**
+ * A schema browser driven by the hooks layer's `useSchemas`. Renders a
+ * `Card` per schema; pass `onSelect` to react to clicks.
+ */
+export function SchemaList({ onSelect, emptyMessage = "No schemas yet." }: SchemaListProps) {
+  const schemas = useSchemas();
+
+  if (schemas === undefined) {
+    return <div className="text-xs text-muted-foreground">Loading schemas…</div>;
+  }
+
+  if (schemas.length === 0) {
+    return <div className="text-xs text-muted-foreground">{emptyMessage}</div>;
+  }
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      {schemas.map((schema) => (
+        <Card key={schema._id} className="p-0">
+          <button type="button" className="w-full text-left" onClick={() => onSelect?.(schema._id)}>
+            <CardHeader className="py-3">
+              <CardTitle className="text-sm">{schema.title}</CardTitle>
+              <CardDescription className="text-xs">{schema.description}</CardDescription>
+            </CardHeader>
+          </button>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/packages/json-cms/src/react/ui/schema-preview.tsx
+++ b/packages/json-cms/src/react/ui/schema-preview.tsx
@@ -1,0 +1,156 @@
+import { useState, useMemo } from "react";
+import Form from "@rjsf/shadcn";
+import validator from "@rjsf/validator-ajv8";
+import { Eye, AlertCircle } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "./primitives/card.js";
+import { cn } from "./lib/utils.js";
+
+interface SchemaPreviewProps {
+  schemaJson: string;
+  uiSchemaJson?: string;
+}
+
+export function SchemaPreview({ schemaJson, uiSchemaJson }: SchemaPreviewProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [formData, setFormData] = useState<unknown>({});
+
+  const { schema, error, uiSchema } = useMemo(() => {
+    if (!schemaJson.trim()) {
+      return { schema: null, error: "Schema is empty", uiSchema: {} };
+    }
+    try {
+      const parsed = JSON.parse(schemaJson);
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        return { schema: null, error: "Schema must be a JSON object", uiSchema: {} };
+      }
+      // Basic validation: check for required fields
+      if (!parsed.title || typeof parsed.title !== "string") {
+        return { schema: null, error: "Schema must have a 'title' property", uiSchema: {} };
+      }
+
+      // Parse uiSchema if provided
+      let parsedUiSchema = {};
+      if (uiSchemaJson?.trim()) {
+        try {
+          const uiParsed = JSON.parse(uiSchemaJson);
+          if (typeof uiParsed === "object" && uiParsed !== null && !Array.isArray(uiParsed)) {
+            parsedUiSchema = uiParsed;
+          }
+        } catch {
+          // Ignore invalid UI schema JSON
+        }
+      }
+
+      return { schema: parsed, error: null, uiSchema: parsedUiSchema };
+    } catch {
+      return { schema: null, error: "Invalid JSON", uiSchema: {} };
+    }
+  }, [schemaJson, uiSchemaJson]);
+
+  // Collapsed state - show a compact card
+  if (!isExpanded) {
+    return (
+      <Card className="mt-4">
+        <button
+          type="button"
+          onClick={() => setIsExpanded(true)}
+          className="w-full text-left"
+        >
+          <CardHeader className="py-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Eye className="h-4 w-4 text-muted-foreground" />
+                <CardTitle className="text-sm">Form Preview</CardTitle>
+              </div>
+              <span className="text-xs text-muted-foreground">Click to expand</span>
+            </div>
+            <CardDescription className="text-xs">
+              Preview how the form will look when creating entries with this schema
+            </CardDescription>
+          </CardHeader>
+        </button>
+      </Card>
+    );
+  }
+
+  // Expanded state - show the form
+  return (
+    <Card className="mt-4">
+      <CardHeader className="py-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Eye className="h-4 w-4 text-muted-foreground" />
+            <CardTitle className="text-sm">Form Preview</CardTitle>
+          </div>
+          <button
+            type="button"
+            onClick={() => setIsExpanded(false)}
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Collapse
+          </button>
+        </div>
+        <CardDescription className="text-xs">
+          Live preview of how the form will appear when creating entries
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {error ? (
+          <div className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-950 px-4 py-3 text-sm text-amber-800 dark:text-amber-200">
+            <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+            <div>
+              <p className="font-medium">Cannot preview form</p>
+              <p className="text-xs text-amber-700 dark:text-amber-300 mt-0.5">{error}</p>
+            </div>
+          </div>
+        ) : (
+          <div
+            className={cn(
+              "rounded-lg border border-border p-4",
+              "[&_.rjsf]:space-y-4",
+              "[&_.field]:space-y-1.5",
+              "[&_label]:text-xs [&_label]:font-medium",
+              "[&_input]:h-8 [&_input]:text-xs [&_input]:rounded-md [&_input]:border [&_input]:border-input [&_input]:px-2.5",
+              "[&_input]:focus-visible:outline-none [&_input]:focus-visible:ring-1 [&_input]:focus-visible:ring-ring",
+              "[&_select]:h-8 [&_select]:text-xs [&_select]:rounded-md [&_select]:border [&_select]:border-input [&_select]:px-2.5",
+              "[&_select]:focus-visible:outline-none [&_select]:focus-visible:ring-1 [&_select]:focus-visible:ring-ring",
+              "[&_textarea]:text-xs [&_textarea]:rounded-md [&_textarea]:border [&_textarea]:border-input [&_textarea]:p-2.5",
+              "[&_textarea]:focus-visible:outline-none [&_textarea]:focus-visible:ring-1 [&_textarea]:focus-visible:ring-ring",
+              "[&_.checkbox]:h-4 [&_.checkbox]:w-4",
+              "[&_button[type='submit']]:h-9 [&_button[type='submit']]:px-4 [&_button[type='submit']]:rounded-md",
+              "[&_button[type='submit']]:bg-primary [&_button[type='submit']]:text-primary-foreground",
+              "[&_button[type='submit']]:text-xs [&_button[type='submit']]:font-medium",
+              "[&_button[type='submit']]:hover:bg-primary/90",
+              "[&_.panel]:rounded-md [&_.panel]:border [&_.panel]:border-border [&_.panel]:p-3 [&_.panel]:space-y-3",
+              "[&_.array-item]:rounded-md [&_.array-item]:border [&_.array-item]:border-border [&_.array-item]:p-3 [&_.array-item]:mb-2",
+              "[&_.array-item-toolbar]:flex [&_.array-item-toolbar]:justify-end [&_.array-item-toolbar]:gap-1 [&_.array-item-toolbar]:mb-2",
+              "[&_.array-item-toolbar_button]:h-6 [&_.array-item-toolbar_button]:w-6 [&_.array-item-toolbar_button]:p-0",
+              "[&_.array-item-add_button]:h-8 [&_.array-item-add_button]:px-3 [&_.array-item-add_button]:text-xs",
+              "[&_.array-item-add_button]:border [&_.array-item-add_button]:border-dashed [&_.array-item-add_button]:border-border",
+              "[&_.error-detail]:text-xs [&_.error-detail]:text-destructive",
+            )}
+          >
+            <Form
+              schema={schema!}
+              validator={validator}
+              formData={formData}
+              onChange={(data) => setFormData(data.formData)}
+              onSubmit={(data) => console.log("Preview form submitted:", data.formData)}
+              uiSchema={{
+                ...uiSchema,
+                "ui:submitButtonOptions": {
+                  submitText: "Create Entry (Preview)",
+                  norender: false,
+                  props: {
+                    disabled: true,
+                    className: "w-full opacity-50 cursor-not-allowed",
+                  },
+                },
+              }}
+            />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/json-cms/src/react/ui/styles.css
+++ b/packages/json-cms/src/react/ui/styles.css
@@ -1,0 +1,129 @@
+@import "tailwindcss";
+@import "tw-animate-css";
+@import "shadcn/tailwind.css";
+@import "@fontsource-variable/inter";
+
+@custom-variant dark (&:is(.dark *));
+
+:root {
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.58 0.22 27);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --chart-1: oklch(0.809 0.105 251.813);
+  --chart-2: oklch(0.623 0.214 259.815);
+  --chart-3: oklch(0.546 0.245 262.881);
+  --chart-4: oklch(0.488 0.243 264.376);
+  --chart-5: oklch(0.424 0.199 265.638);
+  --radius: 0.625rem;
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.87 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.371 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --chart-1: oklch(0.809 0.105 251.813);
+  --chart-2: oklch(0.623 0.214 259.815);
+  --chart-3: oklch(0.546 0.245 262.881);
+  --chart-4: oklch(0.488 0.243 264.376);
+  --chart-5: oklch(0.424 0.199 265.638);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.556 0 0);
+}
+
+@theme inline {
+  --font-sans: "Inter Variable", sans-serif;
+  --color-sidebar-ring: var(--sidebar-ring);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar: var(--sidebar);
+  --color-chart-5: var(--chart-5);
+  --color-chart-4: var(--chart-4);
+  --color-chart-3: var(--chart-3);
+  --color-chart-2: var(--chart-2);
+  --color-chart-1: var(--chart-1);
+  --color-ring: var(--ring);
+  --color-input: var(--input);
+  --color-border: var(--border);
+  --color-destructive: var(--destructive);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-accent: var(--accent);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-muted: var(--muted);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-secondary: var(--secondary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-primary: var(--primary);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-popover: var(--popover);
+  --color-card-foreground: var(--card-foreground);
+  --color-card: var(--card);
+  --color-foreground: var(--foreground);
+  --color-background: var(--background);
+  --radius-sm: calc(var(--radius) * 0.6);
+  --radius-md: calc(var(--radius) * 0.8);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) * 1.4);
+  --radius-2xl: calc(var(--radius) * 1.8);
+  --radius-3xl: calc(var(--radius) * 2.2);
+  --radius-4xl: calc(var(--radius) * 2.6);
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+  html {
+    @apply font-sans;
+  }
+}

--- a/packages/json-cms/src/react/ui/validation-pane.tsx
+++ b/packages/json-cms/src/react/ui/validation-pane.tsx
@@ -1,0 +1,489 @@
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
+import validator from "@rjsf/validator-ajv8";
+import {
+  CheckCircle,
+  XCircle,
+  ChevronDown,
+  ChevronRight,
+  FileJson,
+  Upload,
+  X,
+  Wand2,
+} from "lucide-react";
+import { Button } from "./primitives/button.js";
+import { JsonEditor } from "./primitives/json-editor.js";
+import { Label } from "./primitives/label.js";
+import { ConfirmDialog } from "./primitives/dialog.js";
+import { cn } from "./lib/utils.js";
+import { JsonTree } from "./json-tree.js";
+import { inferSchemaFromData } from "../lib/infer-schema.js";
+import { toast } from "sonner";
+
+export interface ValidationResult {
+  index: number;
+  data: unknown;
+  valid: boolean;
+  failingPaths: Set<string>;
+  errors: Map<string, string>;
+  unknownPaths: Set<string>;
+}
+
+export interface ValidationState {
+  total: number;
+  failingPaths: Map<string, number>;
+}
+
+interface ValidationPaneProps {
+  schemaJson: string;
+  /** Optional externally provided data (e.g. from a dropped data file). Wrapped in object so re-sending identical content triggers the effect. */
+  externalDataText?: { text: string };
+  onInferSchema: (inferredJson: string) => void;
+  onStateChange: (state: ValidationState) => void;
+}
+
+function computeUnknownPaths(
+  data: unknown,
+  schema: Record<string, unknown>,
+  pathPrefix = "",
+): Set<string> {
+  const unknown = new Set<string>();
+  if (typeof data !== "object" || data === null || Array.isArray(data)) return unknown;
+  const schemaProps =
+    typeof schema.properties === "object" && schema.properties !== null
+      ? (schema.properties as Record<string, unknown>)
+      : {};
+  for (const key of Object.keys(data as Record<string, unknown>)) {
+    const keyPath = `${pathPrefix}/${key}`;
+    if (!(key in schemaProps)) {
+      unknown.add(keyPath);
+    } else {
+      const nestedSchema = schemaProps[key];
+      if (typeof nestedSchema === "object" && nestedSchema !== null) {
+        const nestedData = (data as Record<string, unknown>)[key];
+        const nested = computeUnknownPaths(
+          nestedData,
+          nestedSchema as Record<string, unknown>,
+          keyPath,
+        );
+        for (const p of nested) unknown.add(p);
+      }
+    }
+  }
+  return unknown;
+}
+
+export function ValidationPane({
+  schemaJson,
+  externalDataText,
+  onInferSchema,
+  onStateChange,
+}: ValidationPaneProps) {
+  const [dataText, setDataText] = useState("");
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [results, setResults] = useState<ValidationResult[] | null>(null);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [expandedItems, setExpandedItems] = useState<Set<number>>(new Set());
+  const [isInferConfirmOpen, setIsInferConfirmOpen] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Wrap the item schema in an array schema for CodeMirror inline linting
+  const arrayJsonSchema = useMemo(() => {
+    try {
+      const parsed = JSON.parse(schemaJson);
+      if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+        return { type: "array", items: parsed } as object;
+      }
+    } catch {
+      // invalid schema JSON — no inline linting
+    }
+    return undefined;
+  }, [schemaJson]);
+
+  // Apply external data when provided
+  useEffect(() => {
+    if (externalDataText !== undefined) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- syncs internal state to an externally-provided prop (a dropped file's contents), not derivable during render.
+      setDataText(externalDataText.text);
+      setFileName(null);
+    }
+  }, [externalDataText]);
+
+  const validate = useCallback(
+    (text: string, schemaStr: string) => {
+      if (!text.trim()) {
+        setResults(null);
+        setParseError(null);
+        onStateChange({ total: 0, failingPaths: new Map() });
+        return;
+      }
+
+      let parsedData: unknown;
+      try {
+        parsedData = JSON.parse(text);
+      } catch {
+        setParseError("Invalid JSON — please check your input.");
+        setResults(null);
+        onStateChange({ total: 0, failingPaths: new Map() });
+        return;
+      }
+
+      if (!Array.isArray(parsedData)) {
+        setParseError("Data must be a JSON array of objects.");
+        setResults(null);
+        onStateChange({ total: 0, failingPaths: new Map() });
+        return;
+      }
+
+      let parsedSchema: unknown;
+      try {
+        parsedSchema = JSON.parse(schemaStr);
+      } catch {
+        // Schema is invalid — show data without validation
+        setResults(
+          parsedData.map((item, index) => ({
+            index,
+            data: item,
+            valid: false,
+            failingPaths: new Set<string>(),
+            errors: new Map<string, string>(),
+            unknownPaths: new Set<string>(),
+          })),
+        );
+        setParseError(null);
+        onStateChange({ total: parsedData.length, failingPaths: new Map() });
+        return;
+      }
+
+      const newResults: ValidationResult[] = parsedData.map((item, index) => {
+        const { errors } = validator.validateFormData(item, parsedSchema as object);
+        const failingPaths = new Set<string>();
+        const errorMessages = new Map<string, string>();
+        for (const err of errors) {
+          // RJSF property is JS accessor notation: ".email", ".address.city", "."
+          // For required errors, params.missingProperty gives the key
+          let path: string | null = null;
+
+          if (err.name === "required" && err.params && typeof err.params === "object") {
+            const missing = (err.params as Record<string, string>).missingProperty;
+            if (missing) path = `/${missing}`;
+          } else if (err.property && err.property !== ".") {
+            // ".email" → "/email", ".address.city" → "/address/city"
+            const raw = err.property.replace(/^\./, "");
+            path = raw.startsWith("/") ? raw : `/${raw}`;
+          }
+
+          if (path) {
+            failingPaths.add(path);
+            if (!errorMessages.has(path)) {
+              errorMessages.set(path, err.message ?? "Validation error");
+            }
+          }
+        }
+        const unknownPaths = computeUnknownPaths(item, parsedSchema as Record<string, unknown>);
+        return {
+          index,
+          data: item,
+          valid: errors.length === 0,
+          failingPaths,
+          errors: errorMessages,
+          unknownPaths,
+        };
+      });
+
+      setResults(newResults);
+      setParseError(null);
+
+      // Aggregate failing paths across all items
+      const aggregated = new Map<string, number>();
+      for (const r of newResults) {
+        for (const path of r.failingPaths) {
+          aggregated.set(path, (aggregated.get(path) ?? 0) + 1);
+        }
+      }
+      onStateChange({ total: parsedData.length, failingPaths: aggregated });
+    },
+    [onStateChange],
+  );
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- re-validates against the schema/data pair, including an async-looking dependency (validate) that itself calls setState; not expressible as a render-time derivation.
+    validate(dataText, schemaJson);
+  }, [schemaJson, dataText, validate]);
+
+  const loadFile = (file: File) => {
+    if (!file.name.endsWith(".json") && file.type !== "application/json") {
+      toast.error("Please upload a .json file.");
+      return;
+    }
+    setFileName(file.name);
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const text = (e.target?.result as string) ?? "";
+      setDataText(text);
+    };
+    reader.readAsText(file);
+  };
+
+  const clearData = () => {
+    setDataText("");
+    setFileName(null);
+    setResults(null);
+    setParseError(null);
+    setExpandedItems(new Set());
+    onStateChange({ total: 0, failingPaths: new Map() });
+  };
+
+  const doInfer = () => {
+    try {
+      const parsed = JSON.parse(dataText);
+      if (!Array.isArray(parsed)) {
+        toast.error("Data must be a JSON array to infer a schema.");
+        return;
+      }
+      const inferred = inferSchemaFromData(parsed);
+      onInferSchema(JSON.stringify(inferred, null, 2));
+    } catch {
+      toast.error("Invalid JSON — cannot infer schema.");
+    }
+  };
+
+  const handleInfer = () => {
+    if (!dataText.trim()) return;
+    if (schemaJson.trim()) {
+      setIsInferConfirmOpen(true);
+    } else {
+      doInfer();
+    }
+  };
+
+  const toggleExpanded = (index: number) => {
+    setExpandedItems((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) next.delete(index);
+      else next.add(index);
+      return next;
+    });
+  };
+
+  const validCount = results?.filter((r) => r.valid).length ?? 0;
+  const hasData = dataText.trim().length > 0;
+
+  return (
+    <>
+    <ConfirmDialog
+      open={isInferConfirmOpen}
+      onOpenChange={setIsInferConfirmOpen}
+      title="Replace current schema?"
+      description="Inferring a schema from this data will overwrite your current schema. This cannot be undone."
+      confirmLabel="Replace schema"
+      cancelLabel="Cancel"
+      destructive
+      onConfirm={doInfer}
+    />
+    <div className="flex flex-col h-full gap-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+          Validate with Data
+        </span>
+        {hasData && (
+          <button
+            type="button"
+            onClick={clearData}
+            className="text-muted-foreground hover:text-foreground"
+            aria-label="Clear data"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+
+      {!hasData ? (
+        /* ── Empty state ─────────────────────────────────── */
+        <div className="flex flex-col gap-3">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".json,application/json"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) loadFile(file);
+              e.target.value = "";
+            }}
+          />
+          <div
+            role="button"
+            tabIndex={0}
+            aria-label="Drop a JSON file here or click to browse"
+            className={cn(
+              "flex flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed px-4 py-6 text-center transition-colors cursor-pointer",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              isDragging
+                ? "border-primary bg-primary/5 text-primary"
+                : "border-border text-muted-foreground hover:border-primary/50 hover:bg-muted/50",
+            )}
+            onClick={() => fileInputRef.current?.click()}
+            onKeyDown={(e) =>
+              e.key === "Enter" || e.key === " " ? fileInputRef.current?.click() : undefined
+            }
+            onDragOver={(e) => {
+              e.preventDefault();
+              setIsDragging(true);
+            }}
+            onDragLeave={(e) => {
+              if (!e.currentTarget.contains(e.relatedTarget as Node)) setIsDragging(false);
+            }}
+            onDrop={(e) => {
+              e.preventDefault();
+              setIsDragging(false);
+              const file = e.dataTransfer.files[0];
+              if (file) loadFile(file);
+            }}
+          >
+            <FileJson
+              className={cn("h-6 w-6", isDragging ? "text-primary" : "text-muted-foreground")}
+            />
+            <p className="text-xs font-medium">
+              {isDragging ? "Drop your data file here" : "Upload a JSON array to test your schema"}
+            </p>
+            <p className="text-[11px] opacity-70">Drag & drop, or click to browse</p>
+          </div>
+
+          <div className="relative flex items-center gap-2">
+            <div className="flex-1 border-t border-border" />
+            <span className="text-[10px] text-muted-foreground uppercase tracking-wide">
+              or paste
+            </span>
+            <div className="flex-1 border-t border-border" />
+          </div>
+
+          <div className="space-y-1">
+            <Label className="text-xs">JSON Array</Label>
+            <JsonEditor
+              value={dataText}
+              onChange={(v) => setDataText(v)}
+              placeholder={'[\n  { "field": "value" }\n]'}
+              height="160px"
+              disableSchemaLinting
+              jsonSchema={arrayJsonSchema}
+            />
+          </div>
+        </div>
+      ) : (
+        /* ── Data loaded state ───────────────────────────── */
+        <div className="flex flex-col gap-3 flex-1 min-h-0">
+          {/* Summary + actions */}
+          <div className="flex items-center justify-between gap-2 flex-wrap">
+            <div className="flex items-center gap-1.5">
+              {fileName && (
+                <span className="text-xs font-mono text-muted-foreground truncate max-w-28">
+                  {fileName}
+                </span>
+              )}
+              {results && (
+                <span
+                  className={cn(
+                    "text-xs font-medium",
+                    validCount < results.length
+                      ? "text-destructive"
+                      : "text-emerald-600 dark:text-emerald-400",
+                  )}
+                >
+                  {validCount}/{results.length} valid
+                </span>
+              )}
+            </div>
+            <Button type="button" variant="outline" size="xs" onClick={handleInfer}>
+              <Wand2 className="h-3 w-3 mr-1" />
+              Infer schema
+            </Button>
+          </div>
+
+          {parseError && (
+            <div className="flex items-start gap-1.5 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+              <XCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+              {parseError}
+            </div>
+          )}
+
+          {/* Results list */}
+          {results && results.length > 0 && (
+            <div className="flex-1 overflow-y-auto space-y-1 min-h-0">
+              {results.map((r) => {
+                const isExpanded = expandedItems.has(r.index);
+                return (
+                  <div
+                    key={r.index}
+                    className={cn(
+                      "rounded-md border text-xs overflow-hidden",
+                      r.valid
+                        ? "border-emerald-200 dark:border-emerald-900"
+                        : "border-destructive/30",
+                    )}
+                  >
+                    <button
+                      type="button"
+                      className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left hover:bg-muted/50 transition-colors"
+                      onClick={() => toggleExpanded(r.index)}
+                    >
+                      {r.valid ? (
+                        <CheckCircle className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400 shrink-0" />
+                      ) : (
+                        <XCircle className="h-3.5 w-3.5 text-destructive shrink-0" />
+                      )}
+                      <span className="font-medium flex-1">Item {r.index + 1}</span>
+                      {!r.valid && (
+                        <span className="text-[11px] text-destructive">
+                          {r.errors.size} error{r.errors.size !== 1 ? "s" : ""}
+                        </span>
+                      )}
+                      {isExpanded ? (
+                        <ChevronDown className="h-3 w-3 text-muted-foreground shrink-0" />
+                      ) : (
+                        <ChevronRight className="h-3 w-3 text-muted-foreground shrink-0" />
+                      )}
+                    </button>
+                    {isExpanded && (
+                      <div className="border-t border-border px-2.5 py-2 overflow-x-auto bg-muted/20">
+                        <JsonTree data={r.data} failingPaths={r.failingPaths} errors={r.errors} unknownPaths={r.unknownPaths} />
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Edit the raw data */}
+          <div className="space-y-1 border-t border-border pt-3 shrink-0">
+            <div className="flex items-center justify-between">
+              <Label className="text-xs">Raw data</Label>
+              <button
+                type="button"
+                className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-0.5"
+                onClick={() => fileInputRef.current?.click()}
+              >
+                <Upload className="h-3 w-3" />
+                Replace
+              </button>
+            </div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".json,application/json"
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) loadFile(file);
+                e.target.value = "";
+              }}
+            />
+            <JsonEditor value={dataText} onChange={(v) => setDataText(v)} height="140px" disableSchemaLinting jsonSchema={arrayJsonSchema} />
+          </div>
+        </div>
+      )}
+    </div>
+    </>
+  );
+}

--- a/packages/json-cms/src/react/ui/visual-builder.tsx
+++ b/packages/json-cms/src/react/ui/visual-builder.tsx
@@ -1,0 +1,786 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { AlertCircle, ChevronDown, ChevronRight, Plus, Trash2 } from "lucide-react";
+import { Button } from "./primitives/button.js";
+import { Input } from "./primitives/input.js";
+import { Label } from "./primitives/label.js";
+import { Textarea } from "./primitives/textarea.js";
+import { cn } from "./lib/utils.js";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type PropertyType = "string" | "number" | "integer" | "boolean" | "object" | "array";
+
+export interface PropertyDef {
+  id: string;
+  name: string;
+  type: PropertyType;
+  title: string;
+  description: string;
+  required: boolean;
+  // string
+  format: string;
+  minLength: string;
+  maxLength: string;
+  pattern: string;
+  enum: string;
+  // number/integer
+  minimum: string;
+  maximum: string;
+  multipleOf: string;
+  // array
+  itemType: string;
+  minItems: string;
+  maxItems: string;
+  itemSchema: PropertyDef | null; // For array of objects
+  // object
+  properties: PropertyDef[];
+}
+
+export interface SchemaFormData {
+  title: string;
+  description: string;
+  properties: PropertyDef[];
+}
+
+// ─── Serialization ───────────────────────────────────────────────────────────
+
+function makePropertySchema(prop: PropertyDef): Record<string, unknown> {
+  const schema: Record<string, unknown> = {};
+  schema.type = prop.type;
+  if (prop.title) schema.title = prop.title;
+  if (prop.description) schema.description = prop.description;
+
+  if (prop.type === "string") {
+    if (prop.format) schema.format = prop.format;
+    if (prop.minLength !== "") schema.minLength = Number(prop.minLength);
+    if (prop.maxLength !== "") schema.maxLength = Number(prop.maxLength);
+    if (prop.pattern) schema.pattern = prop.pattern;
+    if (prop.enum.trim()) {
+      schema.enum = prop.enum
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+    }
+  }
+
+  if (prop.type === "number" || prop.type === "integer") {
+    if (prop.minimum !== "") schema.minimum = Number(prop.minimum);
+    if (prop.maximum !== "") schema.maximum = Number(prop.maximum);
+    if (prop.multipleOf !== "") schema.multipleOf = Number(prop.multipleOf);
+    if (prop.enum.trim()) {
+      schema.enum = prop.enum
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .map(Number);
+    }
+  }
+
+  if (prop.type === "array") {
+    if (prop.itemType) {
+      if (prop.itemType === "object" && prop.itemSchema) {
+        // Array of objects with defined schema
+        schema.items = makePropertySchema(prop.itemSchema);
+        delete (schema.items as Record<string, unknown>).name;
+        delete (schema.items as Record<string, unknown>).required;
+      } else {
+        // Array of primitives
+        schema.items = { type: prop.itemType };
+      }
+    }
+    if (prop.minItems !== "") schema.minItems = Number(prop.minItems);
+    if (prop.maxItems !== "") schema.maxItems = Number(prop.maxItems);
+  }
+
+  if (prop.type === "object" && prop.properties.length > 0) {
+    const nestedProps: Record<string, unknown> = {};
+    const nestedRequired: string[] = [];
+    for (const child of prop.properties) {
+      nestedProps[child.name] = makePropertySchema(child);
+      if (child.required) nestedRequired.push(child.name);
+    }
+    schema.properties = nestedProps;
+    if (nestedRequired.length > 0) schema.required = nestedRequired;
+  }
+
+  return schema;
+}
+
+export function schemaFormDataToJson(data: SchemaFormData): string {
+  const properties: Record<string, unknown> = {};
+  const required: string[] = [];
+
+  for (const prop of data.properties) {
+    if (!prop.name.trim()) continue;
+    properties[prop.name] = makePropertySchema(prop);
+    if (prop.required) required.push(prop.name);
+  }
+
+  const schema: Record<string, unknown> = {
+    type: "object",
+    title: data.title,
+    description: data.description,
+    properties,
+  };
+  if (required.length > 0) schema.required = required;
+
+  return JSON.stringify(schema, null, 2);
+}
+
+// ─── Deserialization ──────────────────────────────────────────────────────────
+
+let propIdCounter = 0;
+function nextId() {
+  return `prop_${++propIdCounter}`;
+}
+
+function parsePropertyDef(
+  name: string,
+  schema: Record<string, unknown>,
+  requiredSet: Set<string>,
+): PropertyDef {
+  const type = (schema.type as PropertyType) ?? "string";
+  const enumVals = Array.isArray(schema.enum)
+    ? (schema.enum as unknown[]).map(String).join(", ")
+    : "";
+
+  const prop: PropertyDef = {
+    id: nextId(),
+    name,
+    type,
+    title: (schema.title as string) ?? "",
+    description: (schema.description as string) ?? "",
+    required: requiredSet.has(name),
+    format: (schema.format as string) ?? "",
+    minLength: schema.minLength !== undefined ? String(schema.minLength) : "",
+    maxLength: schema.maxLength !== undefined ? String(schema.maxLength) : "",
+    pattern: (schema.pattern as string) ?? "",
+    enum: enumVals,
+    minimum: schema.minimum !== undefined ? String(schema.minimum) : "",
+    maximum: schema.maximum !== undefined ? String(schema.maximum) : "",
+    multipleOf: schema.multipleOf !== undefined ? String(schema.multipleOf) : "",
+    itemType:
+      typeof schema.items === "object" && schema.items !== null
+        ? (((schema.items as Record<string, unknown>).type as string) ?? "")
+        : "",
+    minItems: schema.minItems !== undefined ? String(schema.minItems) : "",
+    maxItems: schema.maxItems !== undefined ? String(schema.maxItems) : "",
+    itemSchema: null,
+    properties: [],
+  };
+
+  if (type === "object" && typeof schema.properties === "object" && schema.properties !== null) {
+    const nestedRequired = new Set<string>(
+      Array.isArray(schema.required) ? (schema.required as string[]) : [],
+    );
+    prop.properties = Object.entries(schema.properties as Record<string, unknown>).map(([k, v]) =>
+      parsePropertyDef(k, v as Record<string, unknown>, nestedRequired),
+    );
+  }
+
+  // Parse array item schema for object arrays
+  if (type === "array" && prop.itemType === "object" && typeof schema.items === "object" && schema.items !== null) {
+    const itemsSchema = schema.items as Record<string, unknown>;
+    if (itemsSchema.type === "object") {
+      prop.itemSchema = parsePropertyDef("item", itemsSchema, new Set());
+    }
+  }
+
+  return prop;
+}
+
+export function jsonToSchemaFormData(json: string): SchemaFormData | null {
+  try {
+    const parsed = JSON.parse(json);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+    const obj = parsed as Record<string, unknown>;
+    const requiredSet = new Set<string>(
+      Array.isArray(obj.required) ? (obj.required as string[]) : [],
+    );
+    const properties =
+      typeof obj.properties === "object" && obj.properties !== null
+        ? Object.entries(obj.properties as Record<string, unknown>).map(([k, v]) =>
+            parsePropertyDef(k, v as Record<string, unknown>, requiredSet),
+          )
+        : [];
+    return {
+      title: (obj.title as string) ?? "",
+      description: (obj.description as string) ?? "",
+      properties,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ─── Default property ─────────────────────────────────────────────────────────
+
+function defaultProp(): PropertyDef {
+  return {
+    id: nextId(),
+    name: "",
+    type: "string",
+    title: "",
+    description: "",
+    required: false,
+    format: "",
+    minLength: "",
+    maxLength: "",
+    pattern: "",
+    enum: "",
+    minimum: "",
+    maximum: "",
+    multipleOf: "",
+    itemType: "",
+    minItems: "",
+    maxItems: "",
+    itemSchema: null,
+    properties: [],
+  };
+}
+
+// ─── PropertyRow ──────────────────────────────────────────────────────────────
+
+const STRING_FORMATS = ["", "email", "uri", "date", "date-time", "time", "password", "hostname"];
+const PROPERTY_TYPES: PropertyType[] = [
+  "string",
+  "number",
+  "integer",
+  "boolean",
+  "object",
+  "array",
+];
+
+function PropertyRow({
+  prop,
+  onChange,
+  onRemove,
+  failingCount,
+  totalDataItems,
+  depth = 0,
+}: {
+  prop: PropertyDef;
+  onChange: (updated: PropertyDef) => void;
+  onRemove: () => void;
+  failingCount: number;
+  totalDataItems: number;
+  depth?: number;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  const set = <K extends keyof PropertyDef>(key: K, value: PropertyDef[K]) =>
+    onChange({ ...prop, [key]: value });
+
+  const hasFailures = failingCount > 0;
+
+  return (
+    <div className={cn("rounded-md border border-border bg-card", depth > 0 && "bg-muted/30")}>
+      {/* Header row */}
+      <div className="flex items-center gap-2 px-3 py-2">
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          className="text-muted-foreground hover:text-foreground flex-shrink-0"
+        >
+          {expanded ? (
+            <ChevronDown className="h-3.5 w-3.5" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5" />
+          )}
+        </button>
+
+        {/* Property name */}
+        <Input
+          value={prop.name}
+          onChange={(e) => set("name", e.target.value)}
+          placeholder="property_name"
+          className="h-6 text-xs font-mono flex-1 min-w-0"
+        />
+
+        {/* Type selector */}
+        <select
+          value={prop.type}
+          onChange={(e) => set("type", e.target.value as PropertyType)}
+          className={cn(
+            "h-6 rounded-md border border-input bg-background px-1.5 text-xs",
+            "focus:outline-none focus:ring-1 focus:ring-ring",
+            "shrink-0",
+          )}
+        >
+          {PROPERTY_TYPES.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+
+        {/* Required toggle */}
+        <label className="flex items-center gap-1 text-xs text-muted-foreground shrink-0 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={prop.required}
+            onChange={(e) => set("required", e.target.checked)}
+            className="h-3 w-3 rounded"
+          />
+          req
+        </label>
+
+        {/* Failing badge */}
+        {totalDataItems > 0 && (
+          <span
+            className={cn(
+              "text-[10px] px-1.5 py-0.5 rounded-full font-medium shrink-0",
+              hasFailures
+                ? "bg-destructive/15 text-destructive"
+                : "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400",
+            )}
+          >
+            {hasFailures ? `${failingCount}/${totalDataItems} fail` : `${totalDataItems} pass`}
+          </span>
+        )}
+
+        {/* Remove */}
+        <button
+          type="button"
+          onClick={onRemove}
+          className="text-muted-foreground hover:text-destructive flex-shrink-0"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      {/* Expanded: advanced options */}
+      {expanded && (
+        <div className="px-3 pb-3 space-y-3 border-t border-border pt-3">
+          <div className="grid grid-cols-2 gap-2">
+            <div className="space-y-1">
+              <Label className="text-xs">Title</Label>
+              <Input
+                value={prop.title}
+                onChange={(e) => set("title", e.target.value)}
+                placeholder="Display name"
+                className="h-6 text-xs"
+              />
+            </div>
+            <div className="space-y-1 col-span-2">
+              <Label className="text-xs">Description</Label>
+              <Input
+                value={prop.description}
+                onChange={(e) => set("description", e.target.value)}
+                placeholder="Field description"
+                className="h-6 text-xs"
+              />
+            </div>
+          </div>
+
+          {/* String-specific */}
+          {prop.type === "string" && (
+            <div className="space-y-2">
+              <div className="grid grid-cols-2 gap-2">
+                <div className="space-y-1">
+                  <Label className="text-xs">Format</Label>
+                  <select
+                    value={prop.format}
+                    onChange={(e) => set("format", e.target.value)}
+                    className="w-full h-6 rounded-md border border-input bg-background px-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+                  >
+                    {STRING_FORMATS.map((f) => (
+                      <option key={f} value={f}>
+                        {f || "(none)"}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="space-y-1">
+                  <Label className="text-xs">Pattern (regex)</Label>
+                  <Input
+                    value={prop.pattern}
+                    onChange={(e) => set("pattern", e.target.value)}
+                    placeholder="^[a-z]+$"
+                    className="h-6 text-xs font-mono"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label className="text-xs">Min length</Label>
+                  <Input
+                    type="number"
+                    min={0}
+                    value={prop.minLength}
+                    onChange={(e) => set("minLength", e.target.value)}
+                    placeholder="0"
+                    className="h-6 text-xs"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label className="text-xs">Max length</Label>
+                  <Input
+                    type="number"
+                    min={0}
+                    value={prop.maxLength}
+                    onChange={(e) => set("maxLength", e.target.value)}
+                    placeholder="∞"
+                    className="h-6 text-xs"
+                  />
+                </div>
+              </div>
+              <div className="space-y-1">
+                <Label className="text-xs">Enum values (comma-separated)</Label>
+                <Input
+                  value={prop.enum}
+                  onChange={(e) => set("enum", e.target.value)}
+                  placeholder="option1, option2, option3"
+                  className="h-6 text-xs"
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Number/integer-specific */}
+          {(prop.type === "number" || prop.type === "integer") && (
+            <div className="space-y-2">
+              <div className="grid grid-cols-3 gap-2">
+                <div className="space-y-1">
+                  <Label className="text-xs">Minimum</Label>
+                  <Input
+                    type="number"
+                    value={prop.minimum}
+                    onChange={(e) => set("minimum", e.target.value)}
+                    placeholder="−∞"
+                    className="h-6 text-xs"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label className="text-xs">Maximum</Label>
+                  <Input
+                    type="number"
+                    value={prop.maximum}
+                    onChange={(e) => set("maximum", e.target.value)}
+                    placeholder="+∞"
+                    className="h-6 text-xs"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label className="text-xs">Multiple of</Label>
+                  <Input
+                    type="number"
+                    min={0}
+                    value={prop.multipleOf}
+                    onChange={(e) => set("multipleOf", e.target.value)}
+                    placeholder="—"
+                    className="h-6 text-xs"
+                  />
+                </div>
+              </div>
+              <div className="space-y-1">
+                <Label className="text-xs">Enum values (comma-separated numbers)</Label>
+                <Input
+                  value={prop.enum}
+                  onChange={(e) => set("enum", e.target.value)}
+                  placeholder="1, 2, 3"
+                  className="h-6 text-xs"
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Array-specific */}
+          {prop.type === "array" && (
+            <div className="space-y-3">
+              <div className="grid grid-cols-3 gap-2">
+                <div className="space-y-1">
+                  <Label className="text-xs">Item type</Label>
+                  <select
+                    value={prop.itemType}
+                    onChange={(e) => {
+                      const newType = e.target.value;
+                      set("itemType", newType);
+                      // Initialize itemSchema when switching to object type
+                      if (newType === "object" && !prop.itemSchema) {
+                        set("itemSchema", { ...defaultProp(), type: "object" });
+                      }
+                    }}
+                    className="w-full h-6 rounded-md border border-input bg-background px-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+                  >
+                    <option value="">(any)</option>
+                    {PROPERTY_TYPES.filter((t) => t !== "array").map((t) => (
+                      <option key={t} value={t}>
+                        {t}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="space-y-1">
+                  <Label className="text-xs">Min items</Label>
+                  <Input
+                    type="number"
+                    min={0}
+                    value={prop.minItems}
+                    onChange={(e) => set("minItems", e.target.value)}
+                    placeholder="0"
+                    className="h-6 text-xs"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label className="text-xs">Max items</Label>
+                  <Input
+                    type="number"
+                    min={0}
+                    value={prop.maxItems}
+                    onChange={(e) => set("maxItems", e.target.value)}
+                    placeholder="∞"
+                    className="h-6 text-xs"
+                  />
+                </div>
+              </div>
+
+              {/* Object item schema editor */}
+              {prop.itemType === "object" && prop.itemSchema && (
+                <div className="space-y-2 pt-2 border-t border-border">
+                  <div className="flex items-center justify-between">
+                    <Label className="text-xs font-medium">Item Object Schema</Label>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="xs"
+                      onClick={() =>
+                        set("itemSchema", {
+                          ...prop.itemSchema!,
+                          properties: [...prop.itemSchema!.properties, defaultProp()],
+                        })
+                      }
+                    >
+                      <Plus className="h-3 w-3 mr-1" />
+                      Add field
+                    </Button>
+                  </div>
+                  {prop.itemSchema.properties.length > 0 && (
+                    <div className="space-y-1.5 pl-2 border-l border-border">
+                      {prop.itemSchema.properties.map((child, i) => (
+                        <PropertyRow
+                          key={child.id}
+                          prop={child}
+                          depth={depth + 1}
+                          failingCount={0}
+                          totalDataItems={0}
+                          onChange={(updated) => {
+                            const next = [...prop.itemSchema!.properties];
+                            next[i] = updated;
+                            set("itemSchema", { ...prop.itemSchema!, properties: next });
+                          }}
+                          onRemove={() => {
+                            const next = prop.itemSchema!.properties.filter((_, j) => j !== i);
+                            set("itemSchema", { ...prop.itemSchema!, properties: next });
+                          }}
+                        />
+                      ))}
+                    </div>
+                  )}
+                  {prop.itemSchema.properties.length === 0 && (
+                    <div className="text-xs text-muted-foreground italic">
+                      No fields defined yet. Click "Add field" to define the object structure.
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Object: nested properties */}
+          {prop.type === "object" && (
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <Label className="text-xs">Nested properties</Label>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="xs"
+                  onClick={() => set("properties", [...prop.properties, defaultProp()])}
+                >
+                  <Plus className="h-3 w-3 mr-1" />
+                  Add
+                </Button>
+              </div>
+              {prop.properties.length > 0 && (
+                <div className="space-y-1.5 pl-2 border-l border-border">
+                  {prop.properties.map((child, i) => (
+                    <PropertyRow
+                      key={child.id}
+                      prop={child}
+                      depth={depth + 1}
+                      failingCount={0}
+                      totalDataItems={0}
+                      onChange={(updated) => {
+                        const next = [...prop.properties];
+                        next[i] = updated;
+                        set("properties", next);
+                      }}
+                      onRemove={() => {
+                        const next = prop.properties.filter((_, j) => j !== i);
+                        set("properties", next);
+                      }}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── VisualBuilder ────────────────────────────────────────────────────────────
+
+interface VisualBuilderProps {
+  schemaJson: string;
+  onChange: (json: string) => void;
+  /** path → count of data items failing at that path */
+  validationFailingPaths: Map<string, number>;
+  totalDataItems: number;
+}
+
+export function VisualBuilder({
+  schemaJson,
+  onChange,
+  validationFailingPaths,
+  totalDataItems,
+}: VisualBuilderProps) {
+  const [formData, setFormData] = useState<SchemaFormData | null>(null);
+  const [parseError, setParseError] = useState(false);
+  // Track when we ourselves triggered the schemaJson change so we don't
+  // re-parse and rebuild PropertyDef objects (which would remount inputs and
+  // lose keyboard focus on every keystroke).
+  const selfChangedRef = useRef(false);
+
+  // Parse incoming schemaJson into formData — but skip when we were the source
+  useEffect(() => {
+    if (selfChangedRef.current) {
+      selfChangedRef.current = false;
+      return;
+    }
+    if (!schemaJson.trim()) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- syncs internal form state to the externally-controlled schemaJson prop; guarded above to skip when this component itself was the source of the change.
+      setFormData({ title: "", description: "", properties: [] });
+      setParseError(false);
+      return;
+    }
+    const parsed = jsonToSchemaFormData(schemaJson);
+    if (parsed) {
+      setFormData(parsed);
+      setParseError(false);
+    } else {
+      setParseError(true);
+    }
+  }, [schemaJson]);
+
+  const handleFormChange = useCallback(
+    (updated: SchemaFormData) => {
+      selfChangedRef.current = true;
+      setFormData(updated);
+      onChange(schemaFormDataToJson(updated));
+    },
+    [onChange],
+  );
+
+  if (parseError) {
+    return (
+      <div className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-950 px-4 py-3 text-sm text-amber-800 dark:text-amber-200">
+        <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+        <span>
+          The JSON has a syntax error. Switch to <strong>Code</strong> view to fix it before editing
+          visually.
+        </span>
+      </div>
+    );
+  }
+
+  if (!formData) return null;
+
+  const set = <K extends keyof SchemaFormData>(key: K, value: SchemaFormData[K]) => {
+    handleFormChange({ ...formData, [key]: value });
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Title & description */}
+      <div className="grid grid-cols-1 gap-3">
+        <div className="space-y-1">
+          <Label htmlFor="vb-title" className="text-xs">
+            Title <span className="text-destructive">*</span>
+          </Label>
+          <Input
+            id="vb-title"
+            value={formData.title}
+            onChange={(e) => set("title", e.target.value)}
+            placeholder="My Schema"
+            className="h-7 text-sm"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="vb-description" className="text-xs">
+            Description <span className="text-destructive">*</span>
+          </Label>
+          <Textarea
+            id="vb-description"
+            value={formData.description}
+            onChange={(e) => set("description", e.target.value)}
+            placeholder="Describe what this schema represents…"
+            rows={2}
+            className="text-sm resize-none"
+          />
+        </div>
+      </div>
+
+      {/* Properties */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label className="text-xs">
+            Properties{" "}
+            <span className="text-muted-foreground font-normal">
+              ({formData.properties.length})
+            </span>
+          </Label>
+          <Button
+            type="button"
+            variant="outline"
+            size="xs"
+            onClick={() => set("properties", [...formData.properties, defaultProp()])}
+          >
+            <Plus className="h-3 w-3 mr-1" />
+            Add property
+          </Button>
+        </div>
+
+        {formData.properties.length === 0 && (
+          <div className="rounded-md border border-dashed border-border px-4 py-6 text-center text-xs text-muted-foreground">
+            No properties yet. Click "Add property" to start building your schema.
+          </div>
+        )}
+
+        <div className="space-y-1.5">
+          {formData.properties.map((prop, i) => {
+            const failingCount = validationFailingPaths.get(`/${prop.name}`) ?? 0;
+            return (
+              <PropertyRow
+                key={prop.id}
+                prop={prop}
+                failingCount={failingCount}
+                totalDataItems={totalDataItems}
+                onChange={(updated) => {
+                  const next = [...formData.properties];
+                  next[i] = updated;
+                  set("properties", next);
+                }}
+                onRemove={() => {
+                  const next = formData.properties.filter((_, j) => j !== i);
+                  set("properties", next);
+                }}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Stacked on `feat/json-cms-react-hooks`. Adds a new, batteries-included `@caden/json-cms/react/ui` entrypoint that ports the app's styled schema-editor UI into the publishable component, built on top of the hooks layer from the previous PR.

### Ported (copied from `app/`, imports rewritten only — no logic changes)

- **Primitives** (`react/ui/primitives/`): `button`, `card`, `dialog` (`ConfirmDialog`), `input`, `label`, `textarea`, `json-editor` (`JsonEditor`, CodeMirror-based)
- **Schema editor family** (`react/ui/`): `schema-editor` (`SchemaEditor`), `visual-builder` (`VisualBuilder`), `validation-pane` (`ValidationPane`, `ValidationState`), `schema-preview` (`SchemaPreview`), `json-tree` (`JsonTree`)
- `react/ui/lib/utils.ts` (`cn()`) and `react/ui/lib/use-color-scheme.ts` (small dependency of `json-editor.tsx` not called out in the original file list, copied alongside it since it's needed to compile)
- `react/ui/styles.css` (Tailwind v4 + design tokens)

`SchemaEditor` and friends reuse the existing hooks-layer `inferSchemaFromData` from `../lib/infer-schema.js` — no duplicate copy was added.

### New components

- **`EntryForm`** (`react/ui/entry-form.tsx`) — thin `@rjsf/shadcn` form wrapper (`schema`/`uiSchema`/`formData`/`disabled`/`submitText`/`onSubmit`), modeled on how `app/src/routes/schemas/$schemaId/create.tsx` renders its RJSF form, merging submit-button options via the hooks layer's `mergeUiSchemas`.
- **`SchemaList`** (`react/ui/schema-list.tsx`) — schema browser driven by `useSchemas()`, rendering a `Card` per schema and calling `onSelect(schema._id)` on click.

### Package changes (`packages/json-cms/package.json`)

New exports:
```json
"./react/ui": { "types": "./dist/react/ui/index.d.ts", "default": "./dist/react/ui/index.js" },
"./react/ui/styles.css": "./src/react/ui/styles.css"
```

New `dependencies` (versions matched to `app/package.json`): `@base-ui/react`, `@codemirror/autocomplete`, `@codemirror/lang-json`, `@codemirror/language`, `@codemirror/lint`, `@rjsf/core`, `@rjsf/shadcn`, `@rjsf/utils`, `@rjsf/validator-ajv8`, `@uiw/codemirror-theme-github`, `@uiw/react-codemirror`, `class-variance-authority`, `clsx`, `codemirror-json-schema`, `lucide-react`, `sonner`, `tailwind-merge`.

New `devDependencies`: `@types/json-schema` (matched to app version).

`react`/`react-dom`/`convex` remain peerDependencies, unchanged.

Consumers of `./react/ui` need **Tailwind v4** configured in their app and should import `@caden/json-cms/react/ui/styles.css` (or equivalent tokens) for the components to render correctly — this package ships the stylesheet but does not bundle a Tailwind build step.

### Notes

- A couple of files needed a small, scoped `eslint-disable` comment (`react-hooks/set-state-in-effect` in `validation-pane.tsx` and `visual-builder.tsx`) — this rule is enforced by this package's `eslint-plugin-react-hooks@^7` config but not by `app/`, which has no ESLint config at all. Component logic itself is unchanged from the app's copy; only the lint suppression comments were added.
- `EntryForm` casts its merged `uiSchema` to `any` when passing it to RJSF's `Form`, since RJSF's generic `UiSchema` type requires statically-known `ui:*`-prefixed keys that this package's framework-agnostic `UiSchema` type (from the hooks layer) can't express.
- Wiring the `example/` app to render these components was **skipped** — `example/` has no Tailwind setup, and the instructions call for skipping in that case.
- Visual verification is pending a running Convex deployment + browser, per the task constraints.

## Verification

From `packages/json-cms`:
- `bun install` (repo root) — resolved cleanly.
- `bun run build` — `tsc` succeeds, emits `dist/react/ui/index.js` and `dist/react/ui/index.d.ts` (confirmed present).
- `bun run typecheck` (`tsc --noEmit && tsc -p example && tsc -p example/convex`) — clean.
- `bun run test` — **32 passing** (unchanged from baseline).
- `bun run lint` — **0 errors**, only pre-existing/`react-refresh` warnings (baseline had these too); ran `bunx oxfmt` on the new files (`entry-form.tsx`, `schema-list.tsx`, `index.ts`) only.

## Test plan

- [x] `bun run build` succeeds and emits `react/ui` dist output
- [x] `bun run typecheck` clean
- [x] `bun run test` — 32/32 passing
- [x] `bun run lint` — 0 errors
- [ ] Manual/visual check in a running app (blocked: no live Convex deployment/browser in this environment)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CHpgFbYdFnDGNdUqvig14P)_