### PR TITLE
refactor(json-cms): make SchemaList backend-agnostic and enforce boundary

### DIFF
--- a/docs/decisions/0001-backend-agnostic-react-ui.md
+++ b/docs/decisions/0001-backend-agnostic-react-ui.md
@@ -1,0 +1,50 @@
+# 1. `react/ui` stays backend-agnostic
+
+- Status: accepted
+- Date: 2026-08
+
+## Context
+
+The `@caden/json-cms` component ships two React entrypoints:
+
+- `@caden/json-cms/react` — a Convex adapter: `JsonCmsProvider` + typed hooks
+  over a host app's exposed functions.
+- `@caden/json-cms/react/ui` — styled components (the `SchemaEditor` family,
+  `EntryForm`, `SchemaList`, and shadcn/base-ui primitives).
+
+Most of the UI is already free of any backend dependency — the `SchemaEditor`
+family, `EntryForm`, the primitives, and the `infer-schema` / `ui-schema`
+utilities are purely prop-driven. Only `SchemaList` reached into the hooks layer
+by calling `useSchemas()`.
+
+We considered splitting the UI into its own backend-agnostic package
+(`@caden/json-schema-ui`), with `@caden/json-cms` as the Convex integration on
+top of it.
+
+## Decision
+
+Keep everything in one package **for now**, but enforce a hard boundary:
+**`react/ui` never imports the backend** (Convex, the hooks layer, the client,
+or generated code). UI components take data + callbacks as props; anything that
+fetches lives in the consumer or a thin container built on the hooks layer.
+
+Concretely:
+
+- `SchemaList` is now prop-driven (`schemas`, `onSelect`) instead of calling
+  `useSchemas()`. It accepts any `{ _id, title, description }[]`.
+- A `no-restricted-imports` ESLint rule scoped to `src/react/ui/**` enforces the
+  boundary so it cannot regress silently.
+
+We defer the actual package split until there is real demand (a second,
+non-Convex consumer, or external users), to avoid multi-package versioning and
+release overhead before it pays for itself.
+
+## Consequences
+
+- The UI is usable with any backend (or none), and the lightweight `react` hooks
+  entry does not drag in the heavy UI dependencies (CodeMirror, RJSF, base-ui).
+- The `react` → `react/ui` dependency only ever points one way (a container may
+  import both; `react/ui` imports neither the hooks nor the client).
+- If a second consumer appears, extracting `react/ui` into a standalone package
+  is a mechanical file move rather than a refactor, because the seam is already
+  clean and machine-enforced.

--- a/packages/json-cms/eslint.config.js
+++ b/packages/json-cms/eslint.config.js
@@ -87,4 +87,34 @@ export default [
       ],
     },
   },
+  // react/ui must stay backend-agnostic: presentational components only, no
+  // Convex, hooks-layer, client, or generated-code imports. See
+  // docs/decisions/0001-backend-agnostic-react-ui.md.
+  {
+    files: ["src/react/ui/**/*.{ts,tsx}"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: [
+                "convex",
+                "convex/*",
+                "**/hooks",
+                "**/hooks.js",
+                "**/provider",
+                "**/provider.js",
+                "**/client",
+                "**/client/*",
+                "**/_generated/*",
+              ],
+              message:
+                "react/ui must stay backend-agnostic — no imports from Convex, the hooks layer, the client, or generated code. Take data + callbacks as props and let a container (or the consumer) do the fetching.",
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];

--- a/packages/json-cms/src/react/ui/README.md
+++ b/packages/json-cms/src/react/ui/README.md
@@ -1,0 +1,52 @@
+# `@caden/json-cms/react/ui`
+
+Styled, **backend-agnostic** React components for building and editing JSON
+schemas and entries: the `SchemaEditor` family, an `EntryForm`, a `SchemaList`,
+and the shadcn/base-ui primitives they use.
+
+## The rule: `react/ui` never imports the backend
+
+Everything in this directory is presentational. It must **not** import from:
+
+- `convex` / `convex/react`
+- the hooks layer (`../hooks`, `../provider`)
+- the Convex client or generated code (`../../client`, `**/_generated`)
+
+Components take **data and callbacks as props** and do no data fetching. This is
+enforced by a `no-restricted-imports` ESLint rule scoped to `src/react/ui/**`.
+
+### Why
+
+- The schema editor, entry form, and primitives are useful with _any_ backend
+  (or none). Keeping them backend-free lets non-Convex users adopt them, and
+  keeps the heavy UI dependencies out of the lightweight `react` hooks entry.
+- It preserves a clean seam: if these are ever split into a standalone
+  `@caden/json-schema-ui` package, extraction is a file move — not a rewrite.
+
+See [`docs/decisions/0001-backend-agnostic-react-ui.md`](../../../../../docs/decisions/0001-backend-agnostic-react-ui.md).
+
+## Wiring to Convex (the container pattern)
+
+Fetch with the hooks layer and pass the result down:
+
+```tsx
+import { useSchemas } from "@caden/json-cms/react";
+import { SchemaList } from "@caden/json-cms/react/ui";
+
+function Schemas({ onSelect }: { onSelect?: (id: string) => void }) {
+  const schemas = useSchemas(); // undefined while loading
+  return <SchemaList schemas={schemas} onSelect={onSelect} />;
+}
+```
+
+`SchemaList` accepts any `{ _id, title, description }[]`, so a Convex `SchemaDoc`
+is assignable directly.
+
+## Styling
+
+These components use Tailwind CSS v4 + shadcn CSS variables. Consumers must have
+Tailwind configured and import the shipped stylesheet:
+
+```ts
+import "@caden/json-cms/react/ui/styles.css";
+```

--- a/packages/json-cms/src/react/ui/index.ts
+++ b/packages/json-cms/src/react/ui/index.ts
@@ -13,7 +13,7 @@ export { JsonTree } from "./json-tree.js";
 export { EntryForm } from "./entry-form.js";
 export type { EntryFormProps } from "./entry-form.js";
 export { SchemaList } from "./schema-list.js";
-export type { SchemaListProps } from "./schema-list.js";
+export type { SchemaListProps, SchemaSummary } from "./schema-list.js";
 
 // Primitives
 export { Button, buttonVariants } from "./primitives/button.js";

--- a/packages/json-cms/src/react/ui/schema-list.tsx
+++ b/packages/json-cms/src/react/ui/schema-list.tsx
@@ -1,23 +1,52 @@
 "use client";
 
-import { useSchemas } from "../hooks.js";
-import type { SchemaId } from "../../client/index.js";
 import { Card, CardHeader, CardTitle, CardDescription } from "./primitives/card.js";
 
+/**
+ * The minimal shape `SchemaList` needs to render an item. Any object with
+ * these fields works — a Convex `SchemaDoc` from `@caden/json-cms/react` is
+ * assignable directly.
+ */
+export interface SchemaSummary {
+  _id: string;
+  title: string;
+  description: string;
+}
+
 export interface SchemaListProps {
+  /**
+   * Schemas to render. Pass `undefined` to show the loading state (e.g. while
+   * a query is in flight). This component does no data fetching — fetch the
+   * data however you like and pass it in.
+   */
+  schemas: readonly SchemaSummary[] | undefined;
   /** Called with the clicked schema's id. */
-  onSelect?: (schemaId: SchemaId) => void;
-  /** Message shown when there are no schemas yet. */
+  onSelect?: (schemaId: string) => void;
+  /** Message shown when there are no schemas. */
   emptyMessage?: string;
 }
 
 /**
- * A schema browser driven by the hooks layer's `useSchemas`. Renders a
- * `Card` per schema; pass `onSelect` to react to clicks.
+ * A backend-agnostic schema browser. Renders a `Card` per schema and calls
+ * `onSelect` with the clicked schema's id.
+ *
+ * It deliberately takes `schemas` as a prop rather than fetching them, so it
+ * works with any backend (or none). To wire it to Convex, fetch with the hooks
+ * layer and pass the result down:
+ *
+ * ```tsx
+ * import { useSchemas } from "@caden/json-cms/react";
+ * import { SchemaList } from "@caden/json-cms/react/ui";
+ *
+ * const schemas = useSchemas();
+ * return <SchemaList schemas={schemas} onSelect={onSelect} />;
+ * ```
  */
-export function SchemaList({ onSelect, emptyMessage = "No schemas yet." }: SchemaListProps) {
-  const schemas = useSchemas();
-
+export function SchemaList({
+  schemas,
+  onSelect,
+  emptyMessage = "No schemas yet.",
+}: SchemaListProps) {
   if (schemas === undefined) {
     return <div className="text-xs text-muted-foreground">Loading schemas…</div>;
   }


### PR DESCRIPTION
## Summary

Makes `react/ui` fully backend-agnostic and locks that property in, so the styled components are usable with any backend (or none) and could later be extracted into a standalone package as a mechanical move.

- **`SchemaList` is now prop-driven.** It takes `schemas` (any `{ _id, title, description }[]` — a Convex `SchemaDoc` is assignable) and `onSelect`, instead of calling `useSchemas()`. This removes the *only* backend coupling in `react/ui`; every component there is now purely presentational.
- **Boundary enforced in CI.** A `no-restricted-imports` ESLint rule scoped to `src/react/ui/**` bans importing `convex`, the hooks layer (`../hooks`, `../provider`), the client, or generated code — so the rule can't regress silently.
- **Decision documented.** A `react/ui` README (the rule + rationale + the container-pattern wiring) and an ADR at `docs/decisions/0001-backend-agnostic-react-ui.md`.

## Wiring stays trivial

The Convex convenience isn't lost — it moves to a one-line container:

```tsx
const schemas = useSchemas();              // @caden/json-cms/react
return <SchemaList schemas={schemas} … />; // @caden/json-cms/react/ui
```

## Why not split into a separate package now

The seam is clean and machine-enforced, but there's one consumer today. Splitting into published packages before a second (non-Convex) consumer exists adds versioning/release overhead for no present payoff. The ADR records the decision to defer the split until there's demand — extraction stays cheap because the boundary is enforced.

## Stack

Tip of the stack; base is `feat/json-cms-react-ui` (PR #7). Merge the stack bottom-up.

## Verification

- `bun run build` — clean
- `bun run lint` — **0 errors** (boundary rule active, no false positives; only pre-existing `react-refresh` warnings)
- `bun run test` — **32 passing**

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHpgFbYdFnDGNdUqvig14P)_